### PR TITLE
Add email and search types to TextField

### DIFF
--- a/src/lib/components/TextField.svelte
+++ b/src/lib/components/TextField.svelte
@@ -22,7 +22,7 @@
 
   export let label = '';
   export let value: InputValue | { [operator: string]: InputValue } = ''; // TODO: Can also include operator: { "operator": "value" }
-  export let type: 'text' | 'password' | 'integer' | 'decimal' | 'currency' | 'percent' = 'text';
+  export let type: 'text' | 'password' | 'integer' | 'decimal' | 'currency' | 'percent' | 'search' | 'email' = 'text';
   export let placeholder = undefined;
   export let error = '';
   export let hint = '';
@@ -66,6 +66,12 @@
       break;
     case 'password':
       inputType = 'password';
+      break;
+    case 'email':
+      inputType = 'email';
+      break;
+    case 'search':
+      inputType = 'search';
       break;
     case 'text':
     default:

--- a/src/routes/docs/components/TextField/+page.md
+++ b/src/routes/docs/components/TextField/+page.md
@@ -201,6 +201,8 @@ docUrl: $docUrl
     <TextField label="decimal" type="decimal" on:change={e => console.log(e.detail)}  />
     <TextField label="currency" type="currency" on:change={e => console.log(e.detail)}  />
     <TextField label="percent" type="percent" on:change={e => console.log(e.detail)}  />
+    <TextField label="email" type="email" on:change={e => console.log(e.detail)}  />
+    <TextField label="search" type="search" on:change={e => console.log(e.detail)}  />
   </div>
 </Preview>
 


### PR DESCRIPTION
These just translate to the `type` parameter on the `input`, and are otherwise treated as normal "text" types.