### PR TITLE
Update instructions to explicitly say not to use tailwindcss-forms

### DIFF
--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -98,6 +98,7 @@ A few notes regarding the config
 
 - Define `accent` color of your choice. Many components utilize this color and more are being updated to do so.
 - Currently `svelte-ux` provides a tailwind plugin to use more [realistic shadows](https://www.joshwcomeau.com/css/designing-shadows/) by having multiple shadow layers, unlike the current Tailwind [shadows](https://tailwindcss.com/docs/box-shadow) which have at most 2 layers, exposed as `elevation-#` classes. This may change in the future.
+- The `tailwindcss-forms` plugin should not be used. The styles that it sets up for inputs conflict with the styles used by `svelte-ux`.
 
 Next, import Tailwind layers in `src/routes/__layout.svelte` style block
 


### PR DESCRIPTION
It adds borders around text fields which look really bad when used in a svelte-ux TextField. Seemed worth noting since it's a very common plugin to use.