### PR TITLE
Add tailwind-merge and use it on AppBar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svelte-ux",
-  "version": "0.22.4",
+  "version": "0.23.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svelte-ux",
-      "version": "0.22.4",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.7",
@@ -22,6 +22,7 @@
         "lodash-es": "^4.17.21",
         "rehype-slug": "^5.1.0",
         "svelte": "^3.53.1",
+        "tailwind-merge": "^1.8.1",
         "zod": "^3.19.1"
       },
       "devDependencies": {
@@ -3122,6 +3123,11 @@
         "typescript": "^4.1.2"
       }
     },
+    "node_modules/tailwind-merge": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
+      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww=="
+    },
     "node_modules/tailwindcss": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.2.4.tgz",
@@ -5661,6 +5667,11 @@
         "dedent-js": "^1.0.1",
         "pascal-case": "^3.1.1"
       }
+    },
+    "tailwind-merge": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-1.8.1.tgz",
+      "integrity": "sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww=="
     },
     "tailwindcss": {
       "version": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lodash-es": "^4.17.21",
     "rehype-slug": "^5.1.0",
     "svelte": "^3.53.1",
+    "tailwind-merge": "^1.8.1",
     "zod": "^3.19.1"
   },
   "peerDependencies": {

--- a/src/lib/components/AppBar.svelte
+++ b/src/lib/components/AppBar.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { mdiMenu } from '@mdi/js';
-  import clsx from 'clsx';
+  import { twMerge } from 'tailwind-merge';
 
   import { showDrawer } from './AppLayout.svelte';
   import Breadcrumb from './Breadcrumb.svelte';
@@ -23,7 +23,7 @@
 </script>
 
 <header
-  class={clsx(
+  class={twMerge(
     'h-16 px-4 bg-blue-500 text-white flex items-center shadow-md relative',
     $$restProps.class
   )}


### PR DESCRIPTION
Noticed that the `bg-white` wasn't taking effect on the AppBar "color" example so I added `twMerge`. Unlike at work I did not use `clsx` on it since twMerge already has its own clsx-like implementation internally.