### PR TITLE
Fix typos in doc site

### DIFF
--- a/src/routes/+page.md
+++ b/src/routes/+page.md
@@ -100,7 +100,7 @@ Next, import Tailwind layers in `src/routes/+layout.svelte` style block
 
 <h1>Usage</h1>
 
-Using `components`, `actions`, or `stores` as as simple as importing from `svelte-ux`
+Using `components`, `actions`, or `stores` is as simple as importing from `svelte-ux`.
 
 ```svelte
 <script>

--- a/src/routes/_NavMenu.svelte
+++ b/src/routes/_NavMenu.svelte
@@ -38,7 +38,7 @@
       'Steps',
       'Table',
     ],
-    Model: [
+    Modal: [
       'Dialog',
       'Drawer',
       'Menu',

--- a/src/routes/customization/+page.md
+++ b/src/routes/customization/+page.md
@@ -74,7 +74,7 @@ Classes are applied in the following order, and [tailwind-merge](https://github.
 
 ## Global classes
 
-All components with top-level elements add a `{ComponentName}` class, to allow easy overriding using global CSS rules, if desired
+All components with top-level elements add a `{ComponentName}` class, to allow easy overriding using global CSS rules, if desired.
 
 ```css
 :global(.Button) {
@@ -128,4 +128,4 @@ Many components expose slots, including `default` and named, to allow customizat
 
 ## Composition
 
-If you find yourself passing the same props repeatily, you may find it useful to use composition to build your own custom components and leverage Svelte UX's components internally
+If you find yourself passing the same props repeatedly, you may find it useful to use composition to build your own custom components and leverage Svelte UX's components internally.


### PR DESCRIPTION
Fixes a couple of typos I noticed on [svelte-ux.techniq.dev](https://svelte-ux.techniq.dev/). 