### PR TITLE
Replace fieldsets with divs.

### DIFF
--- a/src/lib/components/Field.svelte
+++ b/src/lib/components/Field.svelte
@@ -55,8 +55,8 @@
   let labelEl: HTMLLabelElement | null = null;
 </script>
 
-<fieldset
-  {disabled}
+<div
+  role="group"
   class={cls(
     'Field',
     'group flex gap-1',
@@ -165,6 +165,7 @@
             {#if clearable && hasValue}
               <Button
                 icon={mdiClose}
+                {disabled}
                 class="text-black/50 p-1"
                 on:click={() => {
                   value = Array.isArray(value) ? [] : typeof value === 'string' ? '' : null;
@@ -198,11 +199,11 @@
     </div>
   </div>
 
-  <slot name="fieldset" />
-</fieldset>
+  <slot name="root" />
+</div>
 
 <style lang="postcss">
-  fieldset:focus-within label.placement-float,
+  div.Field:focus-within label.placement-float,
   label.shrink {
     transform: scale(0.75);
     width: 133%; /* offset 75% scale */

--- a/src/lib/components/Input.svelte
+++ b/src/lib/components/Input.svelte
@@ -25,6 +25,7 @@
   export let replace = '_';
   export let accept = '\\d';
   export let placeholder = mask;
+  export let disabled = false;
 
   const theme = getComponentTheme('Input');
 
@@ -95,6 +96,7 @@
   {type}
   {inputmode}
   placeholder={isFocused && mask ? mask : placeholder}
+  {disabled}
   {autocapitalize}
   bind:this={inputEl}
   on:keydown={(e) => (backspace = e.key === 'Backspace')}

--- a/src/lib/components/MenuField.svelte
+++ b/src/lib/components/MenuField.svelte
@@ -102,7 +102,7 @@
   </span>
 
   <Menu
-    slot="fieldset"
+    slot="root"
     {open}
     on:close={() => {
       open = false;

--- a/src/lib/components/TextField.svelte
+++ b/src/lib/components/TextField.svelte
@@ -172,8 +172,8 @@
   let labelEl: HTMLLabelElement | null = null;
 </script>
 
-<fieldset
-  {disabled}
+<div
+  role="group"
   class={cls(
     'TextField',
     'group flex gap-1',
@@ -283,6 +283,7 @@
                 {name}
                 {placeholder}
                 {autocomplete}
+                {disabled}
                 value={inputValue}
                 {autocapitalize}
                 on:input={handleInput}
@@ -310,6 +311,7 @@
                 {id}
                 {name}
                 {placeholder}
+                {disabled}
                 {autocomplete}
                 type={inputType}
                 inputmode={inputMode}
@@ -355,6 +357,7 @@
             {#if clearable && hasInputValue}
               <Button
                 icon={mdiClose}
+                {disabled}
                 class="text-black/50 p-1"
                 on:click={() => {
                   inputValue = '';
@@ -368,6 +371,7 @@
 
             {#if operators}
               <select
+                {disabled}
                 value={operator}
                 on:change={(e) => {
                   operator = e.target.value;
@@ -385,6 +389,7 @@
             {#if type === 'password'}
               <Button
                 icon={mdiEye}
+                {disabled}
                 class="text-black/50 p-2"
                 on:click={() => {
                   if (inputType === 'password') {
@@ -420,10 +425,10 @@
       {error && error != true ? error : hint}
     </div>
   </div>
-</fieldset>
+</div>
 
 <style lang="postcss">
-  fieldset:focus-within label.placement-float,
+  div.TextField:focus-within label.placement-float,
   label.shrink {
     transform: scale(0.75);
     width: 133%; /* offset 75% scale */


### PR DESCRIPTION
Closes #108. There are now no more mentions of "fieldset" within the codebase except for a TODO in `ToggleGroup.svelte`.

Note that I had a large number of warnings/errors in my VS Code project, but everything built (and seemed to behave) just fine. May have just misconfigured something on my end, idk.

1. Gave the new `<div>` elements a "group" role.
2. Identified each element/component supporting `disabled` and made sure to pass the parent component's state to it since the `<fieldset>` previously would've affected nested form fields' `disabled` state automatically.
    - The `Input` component did not have a `disabled` property, so I had to add one.

If I missed anything, please feel free to let me know (or just fix w/ a follow-up).