### PR TITLE
Allow mixed null/undefined values in Actions<T>.

### DIFF
--- a/.changeset/old-toes-agree.md
+++ b/.changeset/old-toes-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Modify action declarations to Actions<T> with mixed null/undefined values.

--- a/src/lib/actions/input.ts
+++ b/src/lib/actions/input.ts
@@ -3,7 +3,7 @@ import type { Action } from 'svelte/action';
 /**
  * Auto focus node when rendered.  Useful for inputs
  */
-export const autoFocus: Action<HTMLElement, { delay?: number }> = (node, options?) => {
+export function autoFocus(node: HTMLElement, options?: { delay?: number }) {
   // TODO: Add options to "restoreFocus" on destroy()
   // const elementFocused = document.activeElement as HTMLElement;
   setTimeout(
@@ -82,7 +82,7 @@ export const autoHeight: Action<HTMLTextAreaElement> = (node) => {
  */
 export const debounceEvent: Action<
   HTMLInputElement | HTMLTextAreaElement,
-  { type: string; listener: (e: Event) => any; timeout?: number }
+  { type: string; listener: (e: Event) => any; timeout?: number } | undefined | null
 > = (node, options) => {
   if (options) {
     const { type, listener, timeout } = options;

--- a/src/lib/actions/multi.ts
+++ b/src/lib/actions/multi.ts
@@ -1,6 +1,6 @@
 import type { Action, ActionReturn } from 'svelte/action';
 
-export type Actions<TNode = HTMLElement | SVGElement> = (node: TNode) => ActionReturn[];
+export type Actions<TNode = HTMLElement | SVGElement> = (node: TNode) => (ActionReturn|undefined|null|void)[];
 
 /**
  * Helper action to handle multiple actions as a single action.  Useful for adding actions for custom components

--- a/src/lib/components/TextField.svelte
+++ b/src/lib/components/TextField.svelte
@@ -50,7 +50,7 @@
   export let align: 'left' | 'center' | 'right' = 'left';
   export let autofocus: boolean | Parameters<typeof autoFocus>[1] = false;
   // TODO: Find way to conditionally set type based on `multiline` value
-  export let actions: Actions<HTMLInputElement | HTMLTextAreaElement> = autofocus
+  export let actions: Actions<HTMLInputElement | HTMLTextAreaElement> | undefined = autofocus
     ? (node) => [autoFocus(node, typeof autofocus === 'object' ? autofocus : undefined)]
     : undefined;
   export let operators: { label: string; value: string }[] = undefined;


### PR DESCRIPTION
This removes some typing errors in TextField.svelte (finally figured out how to get the actions to not complain).