### PR TITLE
fix: keyboard shortcut conflict for opening QuickSearch

### DIFF
--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -29,8 +29,9 @@
   */
 
   function onKeyDown(e: KeyboardEvent) {
-    if (e.key === 'k' && e.metaKey) {
-      open = true;
+    if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      open = !open;
     }
   }
 </script>


### PR DESCRIPTION
I use Firefox, and `cmd+k` shortcut, by default, is used to focus the search bar - [ref](https://support.mozilla.org/en-US/kb/keyboard-shortcuts-perform-firefox-tasks-quickly). (Or just test out the site in Firefox)

As such, they always conflict with Svelte-UX's.

This is a fix for that.

Also, I added support for `ctrl+k` on Windows. I don't have a way to test this for Windows, but I'm confident it should work.

Although, there is one thing I couldn't figure out. When I hit `cmd+k`, it works fine, but when I hit `cmd+k` again, it doesn't close the dialog, but this time jumps to the browser's default, and in my case, focuses the search bar. I thought adding `open != open` would fix this, but it didn't. Does the `keyDown` function only apply once and can't be called again? 🤔 

Let me know what you think, @techniq.