### PR TITLE
added use:typeAction instead of binding type in Input.svelte

### DIFF
--- a/packages/svelte-ux/src/lib/components/Input.svelte
+++ b/packages/svelte-ux/src/lib/components/Input.svelte
@@ -40,6 +40,10 @@
   $: firstPlaceholderPos = [...(mask ?? '')].findIndex((c) => replaceSet.has(c));
   $: acceptRegEx = accept instanceof RegExp ? accept : new RegExp(accept, 'g');
 
+  function typeAction(node: HTMLInputElement) {
+    node.type = type;
+  }
+
   function clean(inputValue: string) {
     // Get only accepted characters (no mask)
     const inputMatch = inputValue?.match(acceptRegEx) || [];
@@ -93,7 +97,7 @@
 <input
   {id}
   {value}
-  {type}
+  use:typeAction
   {inputmode}
   placeholder={isFocused && mask ? mask : placeholder}
   {disabled}


### PR DESCRIPTION
I am NOT at all sure if this is the correct fix for this, however, it does resolve the issue with the `'type' attribute must be a static text value if input uses two-way binding` Svelte 5 error. There is still 1 more issue with `TreeList.svelte` after this. I am just hoping to get feedback on this fix.