### PR TITLE
Add renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jycouet/jycouet//shared-config/renovate/default.json5"],
+
+  // Avoid noise in the middle of the day
+  "timezone": "Etc/Greenwich",
+  "schedule": ["after 4am and before 5am"]
+}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,46 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jycouet/jycouet//shared-config/renovate/default.json5"],
+
+  // Extend the base config
+  "extends": ["config:base", ":semanticCommitTypeAll(chore)"],
+
+  // Some tuning that works well for my repos
+  "automerge": false,
+  "rangeStrategy": "replace",
+  "baseBranches": ["main"],
+
+  // For a nice dashboard
+  "dependencyDashboardTitle": "📦 Dependency Dashboard",
+  "labels": ["dependencies"],
 
   // Avoid noise in the middle of the day
-  "timezone": "Etc/Greenwich",
-  "schedule": ["after 4am and before 5am"]
+  "timezone": "EST",
+  "schedule": ["after 1am and before 5am"],
+
+  "packageRules": [
+    // Let's update each patch for these libs
+    {
+      "matchUpdateTypes": ["patch"],
+      "enabled": false,
+      "excludePackagePrefixes": ["layerchart", "svelte-ux"]
+    },
+    // devDependencies will be prioritized last
+    {
+      "matchDepTypes": ["devDependencies"],
+      "prPriority": -1
+    },
+    // Groupings
+    {
+      "groupName": "Svelte",
+      "matchPackagePrefixes": ["@sveltejs", "svelte-check", "svelte"]
+    },
+    {
+      "groupName": "Tailwind",
+      "matchPackagePrefixes": [
+        "@tailwindcss",
+        "tailwindcss",
+        "tailwind-scrollbar"
+      ]
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>jycouet/jycouet//shared-config/renovate"]
-}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jycouet/jycouet//shared-config/renovate"]
+}


### PR DESCRIPTION
I would suggest to add this default. (you can look at details here: https://github.com/jycouet/jycouet/blob/main/shared-config/renovate.json)

It's
- [x] Extending their `config:base` 
- [x] Reducing noice (only minor) 
- [x] add a few groups for svelte

## The best would be to:
1/ Merge this **FIRST** _(to pick up directly the good default)_
2/ Install https://github.com/apps/renovate for this repo
3/ Enjoy 🎉

## What you will get?
- An issue that will auto update for you to get an overview of what is going on. (usually I pin it)
- Some PRs coming from time to time

## What if?
- It's too much? to noisy? => We can tweak configs 👍
- It's really not for you? => We can remove the file `renovate.json`, remove the app, and renovate is gone!

I think that it's worth trying ✅