### PR TITLE
Add svelte settings to .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,14 @@
 {
   "singleQuote": true,
   "printWidth": 100,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-svelte"],
+  "overrides": [
+    {
+      "files": "*.svelte",
+      "options": {
+        "parser": "svelte"
+      }
+    }
+  ]
 }


### PR DESCRIPTION
It was probably working for you since you're in VSCode which handles Prettier rather differently than the normal way, but this makes it work in other editors.