### PR TITLE
Theme store

### DIFF
--- a/.changeset/modern-pumpkins-march.md
+++ b/.changeset/modern-pumpkins-march.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Add a store to manage the current theme

--- a/packages/svelte-ux/src/lib/components/MenuItem.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuItem.svelte
@@ -28,7 +28,7 @@
   setButtonGroup(undefined);
 
   // Clear theme to not expose to Button
-  settings({ ...getSettings(), theme: {} });
+  settings({ ...getSettings(), classes: {} });
 </script>
 
 <Button

--- a/packages/svelte-ux/src/lib/stores/themeStore.ts
+++ b/packages/svelte-ux/src/lib/stores/themeStore.ts
@@ -1,0 +1,86 @@
+import { writable, type Readable } from 'svelte/store';
+import { browser } from '$app/environment';
+
+/** Information about the currently chosen theme. */
+export class CurrentTheme {
+  /** The currently selected theme. If using the "system" theme this will be null. */
+  theme: string | null;
+  /** Whether the current theme is a light or dark theme */
+  dark: boolean;
+
+  constructor(theme: string | null, dark: boolean) {
+    this.theme = theme;
+    this.dark = dark;
+  }
+
+  /** The theme in use, either the selected theme or the theme chosen based on the "system" setting. */
+  get resolvedTheme() {
+    if (this.theme) {
+      return this.theme;
+    } else {
+      return this.dark ? 'dark' : 'light';
+    }
+  }
+}
+
+export interface ThemeStore extends Readable<CurrentTheme> {
+  setTheme: (themeName: string) => void;
+}
+
+export interface ThemeStoreOptions {
+  light: string[];
+  dark: string[];
+}
+
+export function createThemeStore(options: ThemeStoreOptions): ThemeStore {
+  let store = writable<CurrentTheme>(new CurrentTheme(null, false));
+
+  function setTheme(themeName: string) {
+    if (!browser) {
+      // Stub this out for SSR
+      store.set(
+        new CurrentTheme(
+          themeName === 'system' ? null : themeName,
+          options.dark.includes(themeName)
+        )
+      );
+      return;
+    }
+
+    if (themeName === 'system') {
+      // Remove setting
+      localStorage.removeItem('theme');
+      delete document.documentElement.dataset.theme;
+
+      let dark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+      if (dark) {
+        document.documentElement.classList.add('dark');
+      }
+
+      store.set(new CurrentTheme(null, dark));
+    } else {
+      // Save theme to local storage, set `<html data-theme="">`, and set `<html class="dark">` if dark mode
+      localStorage.theme = themeName;
+      document.documentElement.dataset.theme = themeName;
+
+      let dark = options.dark.includes(themeName);
+      if (dark) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
+
+      store.set(new CurrentTheme(themeName, dark));
+    }
+  }
+
+  if (browser) {
+    let savedTheme = localStorage.getItem('theme') || 'system';
+    setTheme(savedTheme);
+  }
+
+  return {
+    subscribe: store.subscribe,
+    setTheme,
+  };
+}

--- a/packages/svelte-ux/src/lib/stores/themeStore.ts
+++ b/packages/svelte-ux/src/lib/stores/themeStore.ts
@@ -1,5 +1,5 @@
 import { writable, type Readable } from 'svelte/store';
-import { browser } from '$app/environment';
+import { browser } from '../utils/env';
 
 /** Information about the currently chosen theme. */
 export class CurrentTheme {

--- a/packages/svelte-ux/src/routes/+layout.svelte
+++ b/packages/svelte-ux/src/routes/+layout.svelte
@@ -96,6 +96,10 @@
         active: 'text-primary bg-surface-100 border-l-4 border-primary font-medium',
       },
     },
+    themes: {
+      light: lightThemes,
+      dark: darkThemes,
+    },
   });
 
   let mainEl: HTMLElement;
@@ -186,7 +190,7 @@
       <QuickSearch options={quickSearchOptions} on:change={(e) => goto(e.detail.value)} />
 
       <div class="border-r border-primary-content/20 pr-2">
-        <ThemeButton {lightThemes} {darkThemes} />
+        <ThemeButton />
       </div>
 
       <Tooltip title="Discord" placement="left" offset={2}>

--- a/packages/svelte-ux/src/routes/customization/+page.md
+++ b/packages/svelte-ux/src/routes/customization/+page.md
@@ -55,7 +55,7 @@ On each `ComponentName: ...` you can pass `class` (when value is a `string`) or 
 import { settings } from 'svelte-ux';
 
 settings({
-  theme: {
+  classes: {
     Button: 'flex-2', // same as <Button class="flex-2">
     TextField: {
       container: 'hover:shadow-none group-focus-within:shadow-none', // same as <TextField classes={{ container: '...' }}>


### PR DESCRIPTION
This moves all the theme management into a store that lives outside any component, to allow multiple ways to set the theme.

The theme store lives in the Settings context. This also allows you to pass the list of themes into `settings`.

This does not cover SSR compatibility, which will come in a later PR