### PR TITLE
Add zero-width-joiner character in import.meta.env to prevent spurious warning from svelte-kit package

### DIFF
--- a/packages/svelte-ux/src/lib/utils/env.ts
+++ b/packages/svelte-ux/src/lib/utils/env.ts
@@ -1,4 +1,4 @@
-// Since it's not recommended to use `$app/environment` or `import.meta.env.SSR`, expose these instead
+// Since it's not recommended to use `$app/environment` or `import.meta.‍env.SSR`, expose these instead
 // See: https://kit.svelte.dev/docs/packaging
 export const browser = typeof window !== 'undefined';
 export const ssr = typeof window === 'undefined';


### PR DESCRIPTION
Run the package command and note the lack of the warning :)

This does show up as `<200d>` in Vim, but it's invisible for VS Code so I think that's ok.