### PR TITLE
feat(DateField): Add support for `class` and `classes` props

### DIFF
--- a/.changeset/silver-penguins-jam.md
+++ b/.changeset/silver-penguins-jam.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': minor
+---
+
+Add support for passing `class` and `classes` props to the DateField component

--- a/packages/svelte-ux/src/lib/components/DateField.svelte
+++ b/packages/svelte-ux/src/lib/components/DateField.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
   import { parse as parseDate, format as formatDate } from 'date-fns';
+  import { cls } from '../utils/styles';
 
   import Field from './Field.svelte';
 
@@ -24,6 +25,15 @@
   export let rounded = false;
   export let dense = false;
   export let icon: string | null = null;
+  export let classes: {
+    root?: string;
+    container?: string;
+    label?: string;
+    input?: string;
+    error?: string;
+    prepend?: string;
+    append?: string;
+  } = {};
 
   const theme = getComponentTheme('DateField');
 
@@ -58,6 +68,8 @@
     inputValue = null;
     dispatch('change', { value });
   }}
+  {classes}
+  class={cls('DateField', $$props.class)}
   let:id
 >
   <Input


### PR DESCRIPTION
This PR adds support for `class` and `classes` props on DateField, and passes a `DateField` class name which can be used to more specifically target DateFields if/when necessary