### PR TITLE
feat(DateField): Add support for `class` and `classes` props

### DIFF
--- a/.changeset/silver-penguins-jam.md
+++ b/.changeset/silver-penguins-jam.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': minor
+---
+
+Add support for passing `class` and `classes` props to the DateField component

--- a/packages/svelte-ux/src/lib/components/DateField.svelte
+++ b/packages/svelte-ux/src/lib/components/DateField.svelte
@@ -22,11 +22,9 @@
   $: actualFormat = format ?? $format_ux.settings.formats.dates.baseParsing ?? 'MM/dd/yyyy';
   $: actualMask = mask ?? actualFormat.toLowerCase();
 
-  type FieldClasses = NonNullable<ComponentProps<Field>['classes']>;
-
   export let classes: {
-    root?: FieldClasses['root'];
-    field?: FieldClasses;
+    root?: string;
+    field?: ComponentProps<Field>['classes'];
   } = {};
 
   // Field props

--- a/packages/svelte-ux/src/lib/components/DateField.svelte
+++ b/packages/svelte-ux/src/lib/components/DateField.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
+  import { createEventDispatcher, type ComponentProps } from 'svelte';
   import { parse as parseDate } from 'date-fns';
   import { PeriodType } from '../utils';
   import { getComponentSettings, getSettings } from './settings';
+  import { cls } from '../utils/styles';
 
   import Field from './Field.svelte';
 
@@ -20,6 +21,13 @@
 
   $: actualFormat = format ?? $format_ux.settings.formats.dates.baseParsing ?? 'MM/dd/yyyy';
   $: actualMask = mask ?? actualFormat.toLowerCase();
+
+  type FieldClasses = NonNullable<ComponentProps<Field>['classes']>;
+
+  export let classes: {
+    root?: FieldClasses['root'];
+    field?: FieldClasses;
+  } = {};
 
   // Field props
   export let label = '';
@@ -46,9 +54,12 @@
       dispatch('change', { value });
     }
   }
+
+  $: restProps = { ...defaults, ...$$restProps };
 </script>
 
 <Field
+  {...restProps}
   {label}
   {value}
   {icon}
@@ -65,6 +76,8 @@
     inputValue = undefined;
     dispatch('change', { value });
   }}
+  classes={classes.field}
+  class={cls('DateField', settingsClasses.root, classes.root, $$props.class)}
   let:id
 >
   <Input


### PR DESCRIPTION
This PR adds support for `class` and `classes` props on DateField, and passes a `DateField` class name which can be used to more specifically target DateFields if/when necessary