### PR TITLE
Place vertical padding on Input element instead of border when not using an inset label

### DIFF
--- a/.changeset/shy-phones-explode.md
+++ b/.changeset/shy-phones-explode.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Improve clickability of TextField when not using an inset label

--- a/packages/svelte-ux/src/lib/components/TextField.svelte
+++ b/packages/svelte-ux/src/lib/components/TextField.svelte
@@ -288,7 +288,7 @@
             class={cls(
               'input col-span-full row-span-full flex items-center',
               hasInsetLabel && 'pt-4',
-              dense ? 'my-1' : 'my-2',
+              hasInsetLabel && (dense ? 'my-1' : 'my-2'),
               (hasPrefix || hasSuffix) &&
                 label &&
                 labelPlacement === 'float' &&
@@ -322,6 +322,7 @@
                   'placeholder-surface-content placeholder-opacity-0 group-focus-within:placeholder-opacity-50',
                   error && 'placeholder-danger',
                   (labelPlacement !== 'float' || !hasInsetLabel) && 'placeholder-opacity-50',
+                  !hasInsetLabel && (dense ? 'py-1' : 'py-2'),
                   {
                     'text-left': align === 'left',
                     'text-center': align === 'center',
@@ -359,6 +360,7 @@
                   'placeholder-surface-content placeholder-opacity-0 group-focus-within:placeholder-opacity-50',
                   error && 'placeholder-danger',
                   (labelPlacement !== 'float' || !hasInsetLabel) && 'placeholder-opacity-50',
+                  !hasInsetLabel && (dense ? 'py-1' : 'py-2'),
                   {
                     'text-left': align === 'left',
                     'text-center': align === 'center',


### PR DESCRIPTION
This almost gets it there... There's still a 1 pixel area where clicking doesn't work right on the border.