### PR TITLE
ToggleOption: Move click handlers from <label> to <input>

### DIFF
--- a/packages/svelte-ux/src/lib/components/ToggleOption.svelte
+++ b/packages/svelte-ux/src/lib/components/ToggleOption.svelte
@@ -45,8 +45,6 @@
 
 <label
   class:selected
-  on:click={() => selectOption(optionElement, value)}
-  on:click
   bind:this={optionElement}
   {...$$restProps}
   class={cls(
@@ -77,7 +75,14 @@
     <slot {selected} />
   </div>
 
-  <input type="radio" bind:value class="appearance-none absolute" checked={selected} />
+  <input
+    on:click={() => selectOption(optionElement, value)}
+    on:click
+    type="radio"
+    bind:value
+    class="appearance-none absolute"
+    checked={selected}
+  />
 </label>
 
 <style lang="postcss">

--- a/packages/svelte-ux/src/lib/styles/theme.ts
+++ b/packages/svelte-ux/src/lib/styles/theme.ts
@@ -111,7 +111,7 @@ export function processThemeColors(
           Object.keys(colors)
             .map((str) => {
               const [c, s] = str.split('-');
-              return [c, Number(s)];
+              return [c, Number(s)] as [string, number];
             })
             .find(([c, s]) => c === color && (s < 500 ? s > shade : s < shade))?.[1] ?? 500;
         const referenceColor = colors[`${color}-${referenceShade}`] ?? colors[color];

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -33,13 +33,13 @@ export type ValueOf<T> = T[keyof T];
 
 // Get keys of object (strongly-typed)
 // Reason Object.keys() isn't like this by default due to runtime properties: https://github.com/Microsoft/TypeScript/pull/12253#issuecomment-263132208
-export function keys<T>(o: T) {
+export function keys<T extends object>(o: T) {
   return Object.keys(o) as (keyof T)[];
 }
 // export const keys = Object.keys as <T>(obj: T) => (Extract<keyof T, string>)[];
 
 // Get entries (array of [key, value] arrays) of object (strongly-typed)
-export function entries<T>(o: T) {
+export function entries<T extends object>(o: T) {
   return Object.entries(o) as [keyof T, T[keyof T]][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
 }
 


### PR DESCRIPTION
This fixes an a11y warning. Browsers fire the click event from the `input` even when the `label` is clicked, so this works. 

We may also want some focus styling on this control to help with keyboard navigation.

Also added some TS type checking fixes.