### PR TITLE
Fix warnings about missing prop settingsClasses.root

### DIFF
--- a/packages/svelte-ux/src/lib/components/AppBar.svelte
+++ b/packages/svelte-ux/src/lib/components/AppBar.svelte
@@ -10,6 +10,8 @@
 
   export let title: string | number | Array<string | number> = '';
   export let menuIcon: string | null = mdiMenu;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   /**
    * Update head / document.title.  Set to false to disable
@@ -31,12 +33,7 @@
 </script>
 
 <header
-  class={cls(
-    'AppBar',
-    'px-4 flex items-center relative z-50',
-    settingsClasses.root,
-    $$restProps.class
-  )}
+  class={cls('AppBar', 'px-4 flex items-center relative z-50', settingsClasses.root, className)}
 >
   {#if menuIcon}
     <slot name="menuIcon" {toggleMenu} isMenuOpen={$showDrawer}>

--- a/packages/svelte-ux/src/lib/components/Avatar.svelte
+++ b/packages/svelte-ux/src/lib/components/Avatar.svelte
@@ -5,6 +5,8 @@
 
   export let size: 'sm' | 'md' | 'lg' | 'unset' = 'md';
   export let icon: string | undefined = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Avatar');
 </script>
@@ -17,9 +19,10 @@
       sm: 'w-6 h-6',
       md: 'w-10 h-10',
       lg: 'w-14 h-14',
+      unset: '',
     }[size],
     settingsClasses.root,
-    $$props.class
+    className
   )}
 >
   <slot>

--- a/packages/svelte-ux/src/lib/components/Backdrop.svelte
+++ b/packages/svelte-ux/src/lib/components/Backdrop.svelte
@@ -7,6 +7,8 @@
 
   export let blur: boolean = false;
   export let portal: PortalOptions = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   export let fadeParams: FadeParams = { duration: 300 };
 
@@ -19,7 +21,7 @@
     'fixed top-0 bottom-0 left-0 right-0 flex items-center justify-center bg-surface-content/50 dark:bg-surface-300/70',
     blur && 'backdrop-blur-sm',
     settingsClasses.root,
-    $$props.class
+    className
   )}
   on:keydown
   on:keyup

--- a/packages/svelte-ux/src/lib/components/Badge.svelte
+++ b/packages/svelte-ux/src/lib/components/Badge.svelte
@@ -6,6 +6,8 @@
   export let small = false;
   export let circle = false;
   export let dot = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   export let placement: 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' = 'top-right';
 
@@ -72,7 +74,7 @@
         'scale-100': (value ?? 0) !== 0,
       },
       settingsClasses.root,
-      $$props.class
+      className
     )}
   >
     <slot name="value">

--- a/packages/svelte-ux/src/lib/components/Breadcrumb.svelte
+++ b/packages/svelte-ux/src/lib/components/Breadcrumb.svelte
@@ -5,9 +5,11 @@
   import { cls } from '../utils/styles';
   import { getComponentClasses } from './theme';
 
-  export let items = [];
+  export let items: (string | null | undefined)[] = [];
   export let divider: string | undefined = undefined;
   export let inline = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Breadcrumb');
 
@@ -21,7 +23,7 @@
     inline ? 'inline-flex' : 'flex',
     'items-center justify-start flex-wrap',
     settingsClasses.root,
-    $$props.class
+    className
   )}
 >
   {#each displayItems as item, index}

--- a/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
+++ b/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
@@ -33,6 +33,8 @@
   export let color: ComponentProps<Button>['color'] | undefined = defaults.color;
   export let rounded: ComponentProps<Button>['rounded'] | undefined = defaults.rounded;
   export let disabled: boolean = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   $: _class = cls(
     'ButtonGroup',
@@ -61,7 +63,7 @@
     '[&.variant-fill-light_:not(:first-child)_.Button]:ml-px',
 
     settingsClasses.root,
-    $$props.class
+    className
   );
 
   setButtonGroup({

--- a/packages/svelte-ux/src/lib/components/Card.svelte
+++ b/packages/svelte-ux/src/lib/components/Card.svelte
@@ -8,11 +8,13 @@
   export let title: string | string[] | null = null;
   export let subheading: string | string[] | null = null;
   export let loading: boolean | null = null;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Card');
 </script>
 
-<!-- 
+<!--
   `position:relative` sets a container for `position:absolute` children (ex. Overlay)
 
   `position: relative` with `z-index` sets new stacking context to keep
@@ -25,7 +27,7 @@
     'Card',
     'relative z-0 bg-surface-100 border rounded elevation-1 flex flex-col justify-between',
     settingsClasses.root,
-    $$props.class
+    className
   )}
 >
   {#if loading}

--- a/packages/svelte-ux/src/lib/components/CopyButton.svelte
+++ b/packages/svelte-ux/src/lib/components/CopyButton.svelte
@@ -5,6 +5,8 @@
   import Button from './Button.svelte';
   import { getComponentSettings } from './settings';
   import { slide } from 'svelte/transition';
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const { classes: settingsClasses, defaults } = getComponentSettings('CopyButton');
 
@@ -21,7 +23,7 @@
 <Button
   icon={mdiContentCopy}
   {...restProps}
-  class={cls('CopyButton', settingsClasses.root, $$props.class)}
+  class={cls('CopyButton', settingsClasses.root, className)}
   on:click={() => {
     navigator.clipboard.writeText(value);
     showMessage = true;

--- a/packages/svelte-ux/src/lib/components/DateButton.svelte
+++ b/packages/svelte-ux/src/lib/components/DateButton.svelte
@@ -20,6 +20,8 @@
   export let fade: boolean = false;
   export let format = getCustomFormat(periodType);
   export let variant = defaults.variant;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const { format: format_ux, localeSettings } = getSettings();
 
@@ -85,7 +87,7 @@
     isSelected && (isVerticalSelection ? 'bg-gradient-to-b' : 'bg-gradient-to-r'),
     hidden && 'opacity-0 pointer-events-none',
     settingsClasses.root,
-    $$props.class
+    className
   )}
 >
   <Button

--- a/packages/svelte-ux/src/lib/components/DateRange.svelte
+++ b/packages/svelte-ux/src/lib/components/DateRange.svelte
@@ -23,6 +23,8 @@
   import { getSettings } from './settings';
 
   export let selected: DateRange | null = { from: null, to: null, periodType: null };
+  let className: string | undefined = undefined;
+  export { className as class };
 
   /** Period types to show */
   export let periodTypes: PeriodType[] = [
@@ -171,7 +173,7 @@
     'w-[min(90vw,384px)]',
     showSidebar && 'md:w-[640px] md:grid-cols-[2fr,3fr]',
     settingsClasses.root,
-    $$props.class
+    className
   )}
 >
   <div class={cls(showSidebar && 'md:col-start-2')}>

--- a/packages/svelte-ux/src/lib/components/Duration.svelte
+++ b/packages/svelte-ux/src/lib/components/Duration.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { DurationUnits, getDuration, humanizeDuration } from '../utils/duration';
+  import { DurationUnits, getDuration, humanizeDuration, type Duration } from '../utils/duration';
   import timerStore from '../stores/timerStore';
   import { getComponentClasses } from './theme';
   import { cls } from '$lib/utils/styles';
@@ -7,9 +7,11 @@
   export let start: Date | undefined = undefined;
   export let end: Date | undefined = undefined;
   export let duration: Partial<Duration> | undefined = undefined;
-  export let minUnits: DurationUnits | undefined = DurationUnits.Millisecond;
+  export let minUnits: DurationUnits = DurationUnits.Millisecond;
   export let totalUnits: number = 99;
   export let variant: 'short' | 'long' = 'short';
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Duration');
 
@@ -57,4 +59,4 @@
   });
 </script>
 
-<span class={cls('Duration', settingsClasses.root, $$props.class)}>{displayDuration}</span>
+<span class={cls('Duration', settingsClasses.root, className)}>{displayDuration}</span>

--- a/packages/svelte-ux/src/lib/components/Form.svelte
+++ b/packages/svelte-ux/src/lib/components/Form.svelte
@@ -10,6 +10,8 @@
 
   export let initial: any = {};
   export let schema: Schema | undefined = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Form');
 
@@ -26,7 +28,7 @@
   on:reset|preventDefault={(e) => {
     draft.revert();
   }}
-  class={cls(settingsClasses.root, $$props.class)}
+  class={cls(settingsClasses.root, className)}
   {...$$restProps}
 >
   <slot

--- a/packages/svelte-ux/src/lib/components/Header.svelte
+++ b/packages/svelte-ux/src/lib/components/Header.svelte
@@ -5,11 +5,13 @@
 
   export let title: string | string[] | null = null;
   export let subheading: string | string[] | null = null;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Header');
 </script>
 
-<div class={cls('Header', 'flex items-center gap-4', settingsClasses.root, $$props.class)}>
+<div class={cls('Header', 'flex items-center gap-4', settingsClasses.root, className)}>
   <slot name="avatar" />
 
   <div class="flex-1">

--- a/packages/svelte-ux/src/lib/components/Input.svelte
+++ b/packages/svelte-ux/src/lib/components/Input.svelte
@@ -20,6 +20,8 @@
   export let actions: Actions<HTMLInputElement | HTMLTextAreaElement> | undefined = undefined;
   export let inputEl: HTMLInputElement | null = null;
   export let autocapitalize: HTMLInputAttributes['autocapitalize'] = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   export let mask = '';
   export let replace = '_';
@@ -136,7 +138,7 @@
     'text-sm w-full outline-none bg-transparent placeholder-surface/50 selection:bg-surface-content/10',
     mask && (mask == placeholder || isFocused || value) && 'font-mono',
     settingsClasses.root,
-    $$props.class
+    className
   )}
 />
 

--- a/packages/svelte-ux/src/lib/components/Lazy.svelte
+++ b/packages/svelte-ux/src/lib/components/Lazy.svelte
@@ -13,6 +13,9 @@
    */
   export let unmount = false;
 
+  let className: string | undefined = undefined;
+  export { className as class };
+
   let show = false;
 
   type Offset = {
@@ -44,7 +47,7 @@
   on:intersecting
   style:min-height={typeof height === 'number' ? `${height}px` : height}
   {...$$restProps}
-  class={cls('Lazy', settingsClasses.root, $$props.class)}
+  class={cls('Lazy', settingsClasses.root, className)}
 >
   {#if show}
     <slot />

--- a/packages/svelte-ux/src/lib/components/NumberStepper.svelte
+++ b/packages/svelte-ux/src/lib/components/NumberStepper.svelte
@@ -11,6 +11,8 @@
   export let value: number = 0;
   export let min: number | undefined = undefined;
   export let max: number | undefined = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('NumberStepper');
 
@@ -23,7 +25,7 @@
   type="integer"
   bind:value
   align="center"
-  class={cls('NumberStepper w-24', settingsClasses.root, $$props.class)}
+  class={cls('NumberStepper w-24', settingsClasses.root, className)}
   actions={(node) => [selectOnFocus(node)]}
   {...$$restProps}
 >

--- a/packages/svelte-ux/src/lib/components/Overlay.svelte
+++ b/packages/svelte-ux/src/lib/components/Overlay.svelte
@@ -10,6 +10,8 @@
     (node: Element, options: any) => TransitionConfig,
     object,
   ];
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Overlay');
 
@@ -22,7 +24,7 @@
     'absolute top-0 bottom-0 left-0 right-0 z-30 bg-surface-100/75',
     center && 'flex items-center justify-center',
     settingsClasses.root,
-    $$props.class
+    className
   )}
   transition:transitionFn={transitionConfig}
 >

--- a/packages/svelte-ux/src/lib/components/Popover.svelte
+++ b/packages/svelte-ux/src/lib/components/Popover.svelte
@@ -8,6 +8,8 @@
 
   export let open = false;
   export let placement: Placement | undefined = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   /**
    * Place popover based on which side of the viewport has more space
@@ -61,7 +63,7 @@
 
 {#if open}
   <div
-    class={cls('Popover absolute z-50 outline-none', settingsClasses.root, $$props.class)}
+    class={cls('Popover absolute z-50 outline-none', settingsClasses.root, className)}
     tabindex="-1"
     use:popover={{ anchorEl, placement, autoPlacement, offset, padding, matchWidth, resize }}
     on:clickOutside={(e) => {

--- a/packages/svelte-ux/src/lib/components/Progress.svelte
+++ b/packages/svelte-ux/src/lib/components/Progress.svelte
@@ -4,6 +4,8 @@
 
   export let value: number | null;
   export let max: number | undefined = undefined;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Progress');
 </script>
@@ -33,6 +35,6 @@
     'rounded-full',
 
     settingsClasses.root,
-    $$props.class
+    className
   )}
 />

--- a/packages/svelte-ux/src/lib/components/ProgressCircle.svelte
+++ b/packages/svelte-ux/src/lib/components/ProgressCircle.svelte
@@ -7,6 +7,8 @@
   export let size = 40;
   export let width = 4;
   export let track = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('ProgressCircle');
 
@@ -26,7 +28,7 @@
     'ProgressCircular',
     'relative inline-flex justify-center items-center align-middle',
     settingsClasses.root,
-    $$props.class
+    className
   )}
   class:indeterminate
   style="height: {size}px; width: {size}px; {$$props.style}"

--- a/packages/svelte-ux/src/lib/components/RangeSlider.svelte
+++ b/packages/svelte-ux/src/lib/components/RangeSlider.svelte
@@ -42,6 +42,9 @@
   export let value = [min, max];
   export let disabled = false;
 
+  let className: string | undefined = undefined;
+  export { className as class };
+
   const settingsClasses = getComponentClasses('RangeSlider');
 
   $: stepPercent = step / (max - min);
@@ -227,7 +230,7 @@
     'group relative h-2 bg-surface-content/10 rounded-full select-none outline-none',
     disabled && ' pointer-events-none opacity-50',
     settingsClasses.root,
-    $$props.class
+    className
   )}
   style="--start: {$start}; --end: {$end};"
   {disabled}

--- a/packages/svelte-ux/src/lib/components/Selection.svelte
+++ b/packages/svelte-ux/src/lib/components/Selection.svelte
@@ -6,7 +6,7 @@
   export let initial: any[] = [];
   export let all: any[] = [];
   export let single = false;
-  export let max = false;
+  export let max: number | undefined = undefined;
 
   const selection = selectionStore({ initial, all, single, max });
   $: $selection.all.set(all);

--- a/packages/svelte-ux/src/lib/components/TableOfContents.svelte
+++ b/packages/svelte-ux/src/lib/components/TableOfContents.svelte
@@ -11,6 +11,8 @@
   export let element = 'main';
   export let maxDepth = 6;
   export let icon = mdiCircleSmall;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   let activeHeadingId = '';
   let headings = [];
@@ -57,7 +59,7 @@
   {nodes}
   classes={{ li: (node) => cls(node.level === 1 ? 'mb-2' : node.level > 2 ? 'ml-3' : '') }}
   {...$$restProps}
-  class={cls('TableOfContents', settingsClasses.root, $$props.class)}
+  class={cls('TableOfContents', settingsClasses.root, className)}
   let:node
 >
   <slot {node} {activeHeadingId}>

--- a/packages/svelte-ux/src/lib/components/Tilt.svelte
+++ b/packages/svelte-ux/src/lib/components/Tilt.svelte
@@ -5,6 +5,8 @@
 
   export let maxRotation = 20;
   export let setBrightness = false;
+  let className: string | undefined = undefined;
+  export { className as class };
 
   const settingsClasses = getComponentClasses('Tilt');
 
@@ -46,7 +48,7 @@
     '[&>*]:[transform:rotateX(var(--rotateX))_rotateY(var(--rotateY))]',
     '[&>*]:brightness-[var(--brightness)]',
     settingsClasses.root,
-    $$props.class
+    className
   )}
   bind:clientWidth={width}
   bind:clientHeight={height}

--- a/packages/svelte-ux/src/lib/components/theme.ts
+++ b/packages/svelte-ux/src/lib/components/theme.ts
@@ -14,7 +14,9 @@ export type ComponentName = keyof typeof Components;
 type ClassesProp<T> = T extends { prototype: infer PR extends SvelteComponent }
   ? ComponentProps<PR> extends { classes?: any }
     ? ComponentProps<PR>['classes']
-    : never
+    : ComponentProps<PR> extends { class?: string }
+      ? { root?: string }
+      : never
   : never;
 
 interface ComponentDefaultProps {


### PR DESCRIPTION
- Update ClassesProp to detect if a `class` string prop exists.
- Add explicit `class` prop where `$$props.class` was used before. This both informs the type system and improves autocomplete experience for users.