### PR TITLE
Sorting + pagination example

### DIFF
--- a/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
@@ -30,8 +30,6 @@
     { id: 13, name: 'Oreo', calories: 437, fat: 18.0, carbs: 63, protein: 4.0 },
   ];
 
-  $: sorted_data = data.sort($order.handler);
-
   function randomDataGen() {
     return data.map((d) => {
       return {
@@ -206,7 +204,7 @@
 <h2>Order + Pagination</h2>
 
 <Preview>
-  <Paginate items={sorted_data} perPage={5} let:pageItems let:pagination>
+  <Paginate items={data.sort($order.handler)} perPage={5} let:pageItems let:pagination>
     <Table
       data={pageItems}
       columns={[
@@ -237,7 +235,11 @@
       ]}
       orderBy={$order.by}
       orderDirection={$order.direction}
-      on:headerClick={(e) => order.onHeaderClick(e.detail.column)}
+      on:headerClick={(e) => {
+        //Switch back to page 1 when sorting
+        pagination.setPage(1);
+        order.onHeaderClick(e.detail.column);
+      }}
     />
     <Pagination
       {pagination}

--- a/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
@@ -30,6 +30,8 @@
     { id: 13, name: 'Oreo', calories: 437, fat: 18.0, carbs: 63, protein: 4.0 },
   ];
 
+  $: sorted_data = data.sort($order.handler)
+
   function randomDataGen() {
     return data.map((d) => {
       return {
@@ -199,6 +201,51 @@
     orderDirection={$order.direction}
     on:headerClick={(e) => order.onHeaderClick(e.detail.column)}
   />
+</Preview>
+
+<h2>Order + Pagination</h2>
+
+<Preview>
+  <Paginate items={sorted_data} perPage={5} let:pageItems let:pagination>
+    <Table
+      data={pageItems}
+      columns={[
+        {
+          name: 'name',
+          align: 'left',
+        },
+        {
+          name: 'calories',
+          align: 'right',
+          format: 'integer',
+        },
+        {
+          name: 'fat',
+          align: 'right',
+          format: 'integer',
+        },
+        {
+          name: 'carbs',
+          align: 'right',
+          format: 'integer',
+        },
+        {
+          name: 'protein',
+          align: 'right',
+          format: 'integer',
+        },
+      ]}
+      orderBy={$order.by}
+      orderDirection={$order.direction}
+      on:headerClick={(e) => order.onHeaderClick(e.detail.column)}      
+    />
+    <Pagination
+      {pagination}
+      perPageOptions={[5, 10, 25, 100]}
+      show={['perPage', 'pagination', 'prevPage', 'nextPage']}
+      classes={{ root: 'border-t py-1 mt-2', perPage: 'flex-1 text-right', pagination: 'px-8' }}
+    />
+  </Paginate>
 </Preview>
 
 <h2>Data background</h2>

--- a/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Table/+page.svelte
@@ -30,7 +30,7 @@
     { id: 13, name: 'Oreo', calories: 437, fat: 18.0, carbs: 63, protein: 4.0 },
   ];
 
-  $: sorted_data = data.sort($order.handler)
+  $: sorted_data = data.sort($order.handler);
 
   function randomDataGen() {
     return data.map((d) => {
@@ -237,7 +237,7 @@
       ]}
       orderBy={$order.by}
       orderDirection={$order.direction}
-      on:headerClick={(e) => order.onHeaderClick(e.detail.column)}      
+      on:headerClick={(e) => order.onHeaderClick(e.detail.column)}
     />
     <Pagination
       {pagination}


### PR DESCRIPTION
Adding a demonstration showing how you can use both pagination and sorting together; hopefully will be useful to someone else. The issue is that if simply combining the two functionalities together, sorting will only occur on the currently active page. If you use a separate reactive declaration and sort that however, the sorting goes across multiple pages.

Hopefully it's a useful addition to the documentation showing a common use case, but if not helpful/doesn't belong, that's OK too!