### PR TITLE
Support classes.icon root and path in NavItem

### DIFF
--- a/packages/svelte-ux/src/lib/components/NavItem.svelte
+++ b/packages/svelte-ux/src/lib/components/NavItem.svelte
@@ -17,7 +17,7 @@
     root?: string;
     active?: string;
     icon?: {
-      root?: string |
+      root?: string,
       path?: string | string[]
     };
   } = {};

--- a/packages/svelte-ux/src/lib/components/NavItem.svelte
+++ b/packages/svelte-ux/src/lib/components/NavItem.svelte
@@ -16,8 +16,8 @@
   export let classes: {
     root?: string;
     active?: string;
-    icon?: string | {
-      root?: string |;
+    icon?: {
+      root?: string |
       path?: string | string[]
     };
   } = {};
@@ -54,7 +54,7 @@
   {/if}
 
   {#if icon}
-    <Icon data={icon} class={cls('mr-3 flex-shrink-0', settingsClasses.icon, (typeof classes.icon === 'string') ? classes.icon : '')} classes={(typeof classes.icon === 'object') ? classes.icon : {}} />
+    <Icon data={icon} class={cls('mr-3 flex-shrink-0', settingsClasses.icon)} classes={classes.icon} />
   {/if}
 
   {text}

--- a/packages/svelte-ux/src/lib/components/NavItem.svelte
+++ b/packages/svelte-ux/src/lib/components/NavItem.svelte
@@ -16,7 +16,10 @@
   export let classes: {
     root?: string;
     active?: string;
-    icon?: string;
+    icon?: string | {
+      root?: string |;
+      path?: string | string[]
+    };
   } = {};
   const settingsClasses = getComponentClasses('NavItem');
 
@@ -51,7 +54,7 @@
   {/if}
 
   {#if icon}
-    <Icon data={icon} class={cls('mr-3 flex-shrink-0', settingsClasses.icon, classes.icon)} />
+    <Icon data={icon} class={cls('mr-3 flex-shrink-0', settingsClasses.icon, (typeof classes.icon === 'string') ? classes.icon : '')} classes={(typeof classes.icon === 'object') ? classes.icon : {}} />
   {/if}
 
   {text}


### PR DESCRIPTION
Added support for classes.icon to be an object to pass to classes instead of class for the Icon. I don't love ternaries, but I didn't want the change to be breaking, so it still supports the original strings. Maybe there's a cleaner way to do this; could probably just make extra variables.