### PR TITLE
Add support for the Map iterable type in the entries function

### DIFF
--- a/.changeset/gold-pumpkins-tell.md
+++ b/.changeset/gold-pumpkins-tell.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Add support for the Map iterable type in the entries function

--- a/packages/svelte-ux/src/lib/actions/scroll.ts
+++ b/packages/svelte-ux/src/lib/actions/scroll.ts
@@ -1,6 +1,6 @@
 import type { Action, ActionReturn } from 'svelte/action';
 import { isVisibleInScrollParent, scrollIntoView as scrollIntoViewUtil } from '../utils/dom.js';
-import type { EventWithTarget } from '../types/index.js';
+import type { EventWithTarget } from '../types/typeHelpers.js';
 
 export type ScrollIntoViewOptions = {
   condition: boolean | ((node: HTMLElement) => boolean);

--- a/packages/svelte-ux/src/lib/actions/scroll.ts
+++ b/packages/svelte-ux/src/lib/actions/scroll.ts
@@ -1,6 +1,6 @@
 import type { Action, ActionReturn } from 'svelte/action';
-import { isVisibleInScrollParent, scrollIntoView as scrollIntoViewUtil } from '$lib/utils/dom.js';
-import type { EventWithTarget } from '$lib/types/index.js';
+import { isVisibleInScrollParent, scrollIntoView as scrollIntoViewUtil } from '../utils/dom.js';
+import type { EventWithTarget } from '../types/index.js';
 
 export type ScrollIntoViewOptions = {
   condition: boolean | ((node: HTMLElement) => boolean);

--- a/packages/svelte-ux/src/lib/actions/styleProps.ts
+++ b/packages/svelte-ux/src/lib/actions/styleProps.ts
@@ -1,13 +1,14 @@
+import { entries, keys } from '$lib/types/typeHelpers.js';
 import type { Action } from 'svelte/action';
 
 type CSSProps = { [key: string]: string | number | boolean | null | undefined };
 
 export const styleProps: Action<HTMLElement, CSSProps> = (node, props) => {
-  Object.entries(props ?? {}).forEach(([key, value]) => {
+  entries(props ?? {}).forEach(([key, value]) => {
     // Ignore if null or undefined
     if (value != null) {
       value = typeof value === 'boolean' ? (value ? 1 : 0) : value;
-      node.style.setProperty(key, `${value}`);
+      node.style.setProperty(String(key), `${value}`);
     }
   });
 
@@ -15,15 +16,15 @@ export const styleProps: Action<HTMLElement, CSSProps> = (node, props) => {
 
   return {
     update(newProps: CSSProps) {
-      const newKeys = Object.keys(newProps);
-      Object.keys(lastProps)
+      const newKeys = keys(newProps);
+      keys(lastProps)
         .filter((key) => !newKeys.includes(key))
         .forEach((key) => node.style.removeProperty(key));
 
-      Object.entries(newProps).forEach(([key, value]) => {
+      entries(newProps).forEach(([key, value]) => {
         // Ignore if null or undefined
         if (value != null) {
-          node.style.setProperty(key, `${value}`);
+          node.style.setProperty(String(key), `${value}`);
         }
         if (props) {
           delete props[key];

--- a/packages/svelte-ux/src/lib/actions/styleProps.ts
+++ b/packages/svelte-ux/src/lib/actions/styleProps.ts
@@ -1,4 +1,4 @@
-import { entries, keys } from '$lib/types/typeHelpers.js';
+import { entries, keys } from '../types/typeHelpers.js';
 import type { Action } from 'svelte/action';
 
 type CSSProps = { [key: string]: string | number | boolean | null | undefined };

--- a/packages/svelte-ux/src/lib/actions/styleProps.ts
+++ b/packages/svelte-ux/src/lib/actions/styleProps.ts
@@ -8,7 +8,7 @@ export const styleProps: Action<HTMLElement, CSSProps> = (node, props) => {
     // Ignore if null or undefined
     if (value != null) {
       value = typeof value === 'boolean' ? (value ? 1 : 0) : value;
-      node.style.setProperty(String(key), `${value}`);
+      node.style.setProperty(String(key), String(value));
     }
   });
 
@@ -24,7 +24,7 @@ export const styleProps: Action<HTMLElement, CSSProps> = (node, props) => {
       entries(newProps).forEach(([key, value]) => {
         // Ignore if null or undefined
         if (value != null) {
-          node.style.setProperty(String(key), `${value}`);
+          node.style.setProperty(String(key), String(value));
         }
         if (props) {
           delete props[key];

--- a/packages/svelte-ux/src/lib/actions/table.ts
+++ b/packages/svelte-ux/src/lib/actions/table.ts
@@ -9,7 +9,7 @@ import { dataBackground } from './dataBackground.js';
 import { sticky } from './sticky.js';
 import { getCellValue } from '../utils/table.js';
 import DomTracker from './_domTracker.js';
-import { entries } from '$lib/types/typeHelpers.js';
+import { entries } from '../types/typeHelpers.js';
 
 type TableCellOptions = {
   column?: ColumnDef;

--- a/packages/svelte-ux/src/lib/actions/table.ts
+++ b/packages/svelte-ux/src/lib/actions/table.ts
@@ -9,6 +9,7 @@ import { dataBackground } from './dataBackground.js';
 import { sticky } from './sticky.js';
 import { getCellValue } from '../utils/table.js';
 import DomTracker from './_domTracker.js';
+import { entries } from '$lib/types/typeHelpers.js';
 
 type TableCellOptions = {
   column?: ColumnDef;
@@ -202,6 +203,6 @@ function getStyleProperties(
       return style.split(':').map((x) => x.trim());
     });
   } else {
-    return Object.entries(resolvedStyleProp);
+    return entries(resolvedStyleProp);
   }
 }

--- a/packages/svelte-ux/src/lib/components/Button.svelte
+++ b/packages/svelte-ux/src/lib/components/Button.svelte
@@ -6,12 +6,7 @@
   import { cls } from '../utils/styles.js';
   import { multi } from '../actions/multi.js';
   import type { Actions } from '../actions/multi.js';
-  import type {
-    ButtonColor,
-    ButtonRounded,
-    ButtonSize,
-    ButtonVariant,
-  } from '../types/index.js';
+  import type { ButtonColor, ButtonRounded, ButtonSize, ButtonVariant } from '../types/index.js';
   import { getButtonGroup } from './ButtonGroup.svelte';
   import { asIconData, type IconInput } from '../utils/icons.js';
   import { getComponentSettings } from './settings.js';

--- a/packages/svelte-ux/src/lib/components/Button.svelte
+++ b/packages/svelte-ux/src/lib/components/Button.svelte
@@ -6,10 +6,14 @@
   import { cls } from '../utils/styles.js';
   import { multi } from '../actions/multi.js';
   import type { Actions } from '../actions/multi.js';
-  import type { ButtonColor, ButtonSize } from '$lib/types/index.js';
+  import type {
+    ButtonColor,
+    ButtonRounded,
+    ButtonSize,
+    ButtonVariant,
+  } from '../types/index.js';
   import { getButtonGroup } from './ButtonGroup.svelte';
-  import { asIconData, type IconInput } from '$lib/utils/icons.js';
-  import type { ButtonRounded, ButtonVariant } from '$lib/types/index.js';
+  import { asIconData, type IconInput } from '../utils/icons.js';
   import { getComponentSettings } from './settings.js';
 
   const { classes: settingsClasses, defaults } = getComponentSettings('Button');

--- a/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
+++ b/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
@@ -1,8 +1,12 @@
 <script lang="ts" context="module">
   import { type ComponentProps, setContext, getContext } from 'svelte';
   import type Button from './Button.svelte';
-  import type { ButtonColor, ButtonSize } from '$lib/types/index.js';
-  import type { ButtonRounded, ButtonVariant } from '$lib/types/index.js';
+  import type {
+    ButtonColor,
+    ButtonRounded,
+    ButtonSize,
+    ButtonVariant,
+  } from '../types/index.js';
 
   type ButtonGroupContext = {
     variant: ButtonVariant | undefined;

--- a/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
+++ b/packages/svelte-ux/src/lib/components/ButtonGroup.svelte
@@ -1,12 +1,7 @@
 <script lang="ts" context="module">
   import { type ComponentProps, setContext, getContext } from 'svelte';
   import type Button from './Button.svelte';
-  import type {
-    ButtonColor,
-    ButtonRounded,
-    ButtonSize,
-    ButtonVariant,
-  } from '../types/index.js';
+  import type { ButtonColor, ButtonRounded, ButtonSize, ButtonVariant } from '../types/index.js';
 
   type ButtonGroupContext = {
     variant: ButtonVariant | undefined;

--- a/packages/svelte-ux/src/lib/components/Code.svelte
+++ b/packages/svelte-ux/src/lib/components/Code.svelte
@@ -2,7 +2,7 @@
   import Prism from 'prismjs';
   import 'prism-svelte';
 
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
   import CopyButton from './CopyButton.svelte';
 

--- a/packages/svelte-ux/src/lib/components/Collapse.svelte
+++ b/packages/svelte-ux/src/lib/components/Collapse.svelte
@@ -5,7 +5,7 @@
   import { cls } from '../utils/styles.js';
 
   import Icon from './Icon.svelte';
-  import type { TransitionParams } from '../types/index.js';
+  import type { TransitionParams } from '../types/typeHelpers.js';
   import { getComponentClasses } from './theme.js';
 
   /**

--- a/packages/svelte-ux/src/lib/components/Collapse.svelte
+++ b/packages/svelte-ux/src/lib/components/Collapse.svelte
@@ -5,7 +5,7 @@
   import { cls } from '../utils/styles.js';
 
   import Icon from './Icon.svelte';
-  import type { TransitionParams } from '$lib/types/index.js';
+  import type { TransitionParams } from '../types/index.js';
   import { getComponentClasses } from './theme.js';
 
   /**

--- a/packages/svelte-ux/src/lib/components/DateRange.svelte
+++ b/packages/svelte-ux/src/lib/components/DateRange.svelte
@@ -19,7 +19,7 @@
   import ToggleGroup from './ToggleGroup.svelte';
   import ToggleOption from './ToggleOption.svelte';
   import { getComponentClasses } from './theme.js';
-  import { mdScreen } from '$lib/stores/matchMedia.js';
+  import { mdScreen } from '../stores/matchMedia.js';
   import { getSettings } from './settings.js';
 
   export let selected: DateRange | null = { from: null, to: null, periodType: null };

--- a/packages/svelte-ux/src/lib/components/Duration.svelte
+++ b/packages/svelte-ux/src/lib/components/Duration.svelte
@@ -7,7 +7,7 @@
   } from '../utils/duration.js';
   import timerStore from '../stores/timerStore.js';
   import { getComponentClasses } from './theme.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   export let start: Date | undefined = undefined;
   export let end: Date | undefined = undefined;

--- a/packages/svelte-ux/src/lib/components/Form.svelte
+++ b/packages/svelte-ux/src/lib/components/Form.svelte
@@ -4,7 +4,7 @@
 
   import formStore from '../stores/formStore.js';
   import { getComponentClasses } from './theme.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   const dispatch = createEventDispatcher();
 

--- a/packages/svelte-ux/src/lib/components/Gooey.svelte
+++ b/packages/svelte-ux/src/lib/components/Gooey.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import type { SVGAttributes } from 'svelte/elements';
 
-  import { uniqueId } from '$lib/utils/string.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { uniqueId } from '../utils/string.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   /** Apply gaussian blur.  Required unless blurring externally (`filter: blur()`, etc) */

--- a/packages/svelte-ux/src/lib/components/Header.svelte
+++ b/packages/svelte-ux/src/lib/components/Header.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import Breadcrumb from './Breadcrumb.svelte';
   import { getComponentClasses } from './theme.js';
 

--- a/packages/svelte-ux/src/lib/components/Kbd.svelte
+++ b/packages/svelte-ux/src/lib/components/Kbd.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   // keys
   export let control = false;

--- a/packages/svelte-ux/src/lib/components/Lazy.svelte
+++ b/packages/svelte-ux/src/lib/components/Lazy.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { intersection } from '../actions/observer.js';
   import { getComponentClasses } from './theme.js';
 

--- a/packages/svelte-ux/src/lib/components/Menu.svelte
+++ b/packages/svelte-ux/src/lib/components/Menu.svelte
@@ -8,7 +8,7 @@
   import { cls } from '../utils/styles.js';
 
   import Popover from './Popover.svelte';
-  import type { TransitionParams } from '$lib/types/index.js';
+  import type { TransitionParams } from '../types/index.js';
   import { getComponentClasses } from './theme.js';
 
   const dispatch = createEventDispatcher();

--- a/packages/svelte-ux/src/lib/components/Menu.svelte
+++ b/packages/svelte-ux/src/lib/components/Menu.svelte
@@ -8,7 +8,7 @@
   import { cls } from '../utils/styles.js';
 
   import Popover from './Popover.svelte';
-  import type { TransitionParams } from '../types/index.js';
+  import type { TransitionParams } from '../types/typeHelpers.js';
   import { getComponentClasses } from './theme.js';
 
   const dispatch = createEventDispatcher();

--- a/packages/svelte-ux/src/lib/components/MenuButton.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuButton.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '../types/typeHelpers.js';
+  import {
+    createEventDispatcher,
+    type ComponentProps,
+  } from 'svelte';
   import { getComponentSettings } from './settings.js';
   import { mdiMenuDown } from '@mdi/js';
 

--- a/packages/svelte-ux/src/lib/components/MenuButton.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '$lib/types/index.js';
+  import type { ComponentProps } from '../types/index.js';
   import { getComponentSettings } from './settings.js';
   import { mdiMenuDown } from '@mdi/js';
 

--- a/packages/svelte-ux/src/lib/components/MenuButton.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuButton.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  import {
-    createEventDispatcher,
-    type ComponentProps,
-  } from 'svelte';
+  import { createEventDispatcher, type ComponentProps } from 'svelte';
   import { getComponentSettings } from './settings.js';
   import { mdiMenuDown } from '@mdi/js';
 

--- a/packages/svelte-ux/src/lib/components/MenuButton.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '../types/index.js';
+  import type { ComponentProps } from '../types/typeHelpers.js';
   import { getComponentSettings } from './settings.js';
   import { mdiMenuDown } from '@mdi/js';
 

--- a/packages/svelte-ux/src/lib/components/MenuField.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuField.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '../types/typeHelpers.js';
+  import { createEventDispatcher, type ComponentProps } from 'svelte';
   import { mdiChevronLeft, mdiChevronRight, mdiMenuDown } from '@mdi/js';
 
   import { cls } from '../utils/styles.js';

--- a/packages/svelte-ux/src/lib/components/MenuField.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuField.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '../types/index.js';
+  import type { ComponentProps } from '../types/typeHelpers.js';
   import { mdiChevronLeft, mdiChevronRight, mdiMenuDown } from '@mdi/js';
 
   import { cls } from '../utils/styles.js';

--- a/packages/svelte-ux/src/lib/components/MenuField.svelte
+++ b/packages/svelte-ux/src/lib/components/MenuField.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import type { ComponentProps } from '$lib/types/index.js';
+  import type { ComponentProps } from '../types/index.js';
   import { mdiChevronLeft, mdiChevronRight, mdiMenuDown } from '@mdi/js';
 
   import { cls } from '../utils/styles.js';
@@ -10,7 +10,7 @@
   import Menu from './Menu.svelte';
   import MenuItem from './MenuItem.svelte';
   import Button from './Button.svelte';
-  import type { MenuOption } from '$lib/types/index.js';
+  import type { MenuOption } from '../types/index.js';
   import { getComponentSettings } from './settings.js';
 
   const { classes: settingsClasses, defaults } = getComponentSettings('MenuField');

--- a/packages/svelte-ux/src/lib/components/MultiSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelect.svelte
@@ -15,7 +15,7 @@
   import dirtyStore from '../stores/dirtyStore.js';
   import selectionStore from '../stores/selectionStore.js';
   import uniqueStore from '../stores/uniqueStore.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   type Option = $$Generic;
 

--- a/packages/svelte-ux/src/lib/components/MultiSelectMenu.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelectMenu.svelte
@@ -5,7 +5,7 @@
 
   import Menu from './Menu.svelte';
 
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import MultiSelect from './MultiSelect.svelte';
   import MultiSelectOption from './MultiSelectOption.svelte';
 

--- a/packages/svelte-ux/src/lib/components/NumberStepper.svelte
+++ b/packages/svelte-ux/src/lib/components/NumberStepper.svelte
@@ -4,9 +4,9 @@
 
   import Button from './Button.svelte';
   import TextField from './TextField.svelte';
-  import { selectOnFocus } from '$lib/actions/input.js';
+  import { selectOnFocus } from '../actions/input.js';
   import { getComponentClasses } from './theme.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   export let value: number = 0;
   export let min: number | undefined = undefined;

--- a/packages/svelte-ux/src/lib/components/Overflow.svelte
+++ b/packages/svelte-ux/src/lib/components/Overflow.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { overflow } from '$lib/actions/layout.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { overflow } from '../actions/layout.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   const settingsClasses = getComponentClasses('Overflow');

--- a/packages/svelte-ux/src/lib/components/Preview.svelte
+++ b/packages/svelte-ux/src/lib/components/Preview.svelte
@@ -7,7 +7,7 @@
 
   import Button from './Button.svelte';
   import Code from './Code.svelte';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   export let code: string | null = null;
   export let language = 'svelte';

--- a/packages/svelte-ux/src/lib/components/Progress.svelte
+++ b/packages/svelte-ux/src/lib/components/Progress.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   export let value: number | null;

--- a/packages/svelte-ux/src/lib/components/ProgressCircle.svelte
+++ b/packages/svelte-ux/src/lib/components/ProgressCircle.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   export let value: number | null = null;

--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
   import { mdiMagnify } from '@mdi/js';
 
-  import Button from '$lib/components/Button.svelte';
-  import Dialog from '$lib/components/Dialog.svelte';
+  import Button from '../components/Button.svelte';
+  import Dialog from '../components/Dialog.svelte';
   import Kbd from './Kbd.svelte';
-  import SelectField from '$lib/components/SelectField.svelte';
+  import SelectField from '../components/SelectField.svelte';
   import { getComponentClasses } from './theme.js';
-  import { cls } from '$lib/utils/styles.js';
-  import { smScreen } from '$lib/stores/matchMedia.js';
-  import { autoFocus, selectOnFocus } from '$lib/actions/input.js';
-  import type { MenuOption } from '$lib/types/index.js';
+  import { cls } from '../utils/styles.js';
+  import { smScreen } from '../stores/matchMedia.js';
+  import { autoFocus, selectOnFocus } from '../actions/input.js';
+  import type { MenuOption } from '../types/index.js';
 
   export let options: MenuOption[] = [];
 

--- a/packages/svelte-ux/src/lib/components/RangeSlider.svelte
+++ b/packages/svelte-ux/src/lib/components/RangeSlider.svelte
@@ -30,8 +30,8 @@
   import { scaleLinear } from 'd3-scale';
   import { mdiDragHorizontal } from '@mdi/js';
 
-  import { movable } from '$lib/actions/mouse.js';
-  import { decimalCount, round } from '$lib/utils/number.js';
+  import { movable } from '../actions/mouse.js';
+  import { decimalCount, round } from '../utils/number.js';
   import Icon from './Icon.svelte';
   import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';

--- a/packages/svelte-ux/src/lib/components/ScrollingValue.svelte
+++ b/packages/svelte-ux/src/lib/components/ScrollingValue.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   import { spring, tweened } from 'svelte/motion';
   import { elasticOut, backInOut, bounceOut } from 'svelte/easing';
-  import { cls } from '$lib/utils/styles.js';
-  import { modulo } from '$lib/utils/number.js';
+  import { cls } from '../utils/styles.js';
+  import { modulo } from '../utils/number.js';
   import { getComponentClasses } from './theme.js';
 
   export let value = 0;

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -5,7 +5,7 @@
   import { mdiChevronDown, mdiChevronLeft, mdiChevronRight, mdiClose } from '@mdi/js';
 
   import Logger from '../utils/logger.js';
-  import { autoFocus, selectOnFocus } from '$lib/actions/input.js';
+  import { autoFocus, selectOnFocus } from '../actions/input.js';
   import { cls } from '../utils/styles.js';
 
   import Button from './Button.svelte';
@@ -15,9 +15,9 @@
   import SelectListOptions from './_SelectListOptions.svelte';
   import TextField from './TextField.svelte';
   import { getComponentSettings } from './settings.js';
-  import type { IconInput } from '$lib/utils/icons.js';
-  import type { MenuOption } from '$lib/types/index.js';
-  import type { ScrollIntoViewOptions } from '$lib/actions/scroll.js';
+  import type { IconInput } from '../utils/icons.js';
+  import type { MenuOption } from '../types/index.js';
+  import type { ScrollIntoViewOptions } from '../actions/scroll.js';
 
   const dispatch = createEventDispatcher<{
     change: { value: any; option: any };

--- a/packages/svelte-ux/src/lib/components/Shine.svelte
+++ b/packages/svelte-ux/src/lib/components/Shine.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { uniqueId } from '$lib/utils/string.js';
-  import { cls } from '$lib/utils/styles.js';
+  import { uniqueId } from '../utils/string.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   /** Color of light */

--- a/packages/svelte-ux/src/lib/components/Switch.svelte
+++ b/packages/svelte-ux/src/lib/components/Switch.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { ThemeColors } from '../types/index.js';
+  import type { ThemeColors } from '../types/typeHelpers.js';
   import { uniqueId } from '../utils/string.js';
   import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';

--- a/packages/svelte-ux/src/lib/components/Switch.svelte
+++ b/packages/svelte-ux/src/lib/components/Switch.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { ThemeColors } from '$lib/types/index.js';
-  import { uniqueId } from '$lib/utils/string.js';
+  import type { ThemeColors } from '../types/index.js';
+  import { uniqueId } from '../utils/string.js';
   import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 

--- a/packages/svelte-ux/src/lib/components/Table.svelte
+++ b/packages/svelte-ux/src/lib/components/Table.svelte
@@ -10,7 +10,7 @@
   import TableOrderIcon from './TableOrderIcon.svelte';
   import { getComponentClasses } from './theme.js';
   import { getSettings } from './settings.js';
-  import type { tableOrderStore } from '$lib/index.js';
+  import type { tableOrderStore } from '../index.js';
 
   type T = $$Generic;
 

--- a/packages/svelte-ux/src/lib/components/Table.svelte
+++ b/packages/svelte-ux/src/lib/components/Table.svelte
@@ -10,7 +10,7 @@
   import TableOrderIcon from './TableOrderIcon.svelte';
   import { getComponentClasses } from './theme.js';
   import { getSettings } from './settings.js';
-  import type { tableOrderStore } from '../index.js';
+  import tableOrderStore from '../stores/tableOrderStore.js';
 
   type T = $$Generic;
 

--- a/packages/svelte-ux/src/lib/components/TableOrderIcon.svelte
+++ b/packages/svelte-ux/src/lib/components/TableOrderIcon.svelte
@@ -4,7 +4,7 @@
   import type tableOrderStore from '../stores/tableOrderStore.js';
   import type { ColumnDef } from '../types/table.js';
   import Icon from '../components/Icon.svelte';
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
 
   export let order: ReturnType<typeof tableOrderStore>;
   export let column: ColumnDef;

--- a/packages/svelte-ux/src/lib/components/TextField.svelte
+++ b/packages/svelte-ux/src/lib/components/TextField.svelte
@@ -15,7 +15,7 @@
   import Button from './Button.svelte';
   import Icon from './Icon.svelte';
   import Input from './Input.svelte';
-  import { type IconInput, asIconData } from '$lib/utils/icons.js';
+  import { type IconInput, asIconData } from '../utils/icons.js';
 
   type InputValue = string | number;
 

--- a/packages/svelte-ux/src/lib/components/Tilt.svelte
+++ b/packages/svelte-ux/src/lib/components/Tilt.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { scaleLinear } from 'd3-scale';
   import { getComponentClasses } from './theme.js';
 

--- a/packages/svelte-ux/src/lib/components/ToggleButton.svelte
+++ b/packages/svelte-ux/src/lib/components/ToggleButton.svelte
@@ -3,7 +3,7 @@
   import Toggle from './Toggle.svelte';
 
   import { fade } from 'svelte/transition';
-  import type { TransitionParams } from '../types/index.js';
+  import type { TransitionParams } from '../types/typeHelpers.js';
   import { getComponentSettings } from './settings.js';
 
   const { classes: settingsClasses, defaults } = getComponentSettings('ToggleButton');

--- a/packages/svelte-ux/src/lib/components/ToggleButton.svelte
+++ b/packages/svelte-ux/src/lib/components/ToggleButton.svelte
@@ -3,7 +3,7 @@
   import Toggle from './Toggle.svelte';
 
   import { fade } from 'svelte/transition';
-  import type { TransitionParams } from '$lib/types/index.js';
+  import type { TransitionParams } from '../types/index.js';
   import { getComponentSettings } from './settings.js';
 
   const { classes: settingsClasses, defaults } = getComponentSettings('ToggleButton');

--- a/packages/svelte-ux/src/lib/components/TreeList.svelte
+++ b/packages/svelte-ux/src/lib/components/TreeList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { cls } from '$lib/utils/styles.js';
+  import { cls } from '../utils/styles.js';
   import { getComponentClasses } from './theme.js';
 
   type Node = { id: number; name: string; level: number; children: Node[] };

--- a/packages/svelte-ux/src/lib/components/settings.ts
+++ b/packages/svelte-ux/src/lib/components/settings.ts
@@ -6,16 +6,16 @@ import {
   resolveComponentClasses,
   type ResolvedDefaultProps,
 } from './theme.js';
-import { createThemeStore, type ThemeStore } from '$lib/stores/themeStore.js';
-import type { LabelPlacement } from '$lib/types/index.js';
+import { createThemeStore, type ThemeStore } from '../stores/themeStore.js';
+import type { LabelPlacement } from '../types/index.js';
 import {
   getAllKnownLocales,
   localeStore,
   type LocaleSettings,
   type LocaleStore,
   type LocaleSettingsInput,
-} from '$lib/utils/locale.js';
-import { buildFormatters, type FormatFunctions } from '$lib/utils/format.js';
+} from '../utils/locale.js';
+import { buildFormatters, type FormatFunctions } from '../utils/format.js';
 import { type Readable, derived } from 'svelte/store';
 
 export interface DefaultProps {

--- a/packages/svelte-ux/src/lib/components/theme.ts
+++ b/packages/svelte-ux/src/lib/components/theme.ts
@@ -7,7 +7,7 @@ import type {
   ButtonSize,
   ButtonVariant,
   LabelPlacement,
-} from '$lib/types/index.js';
+} from '../types/index.js';
 
 export type ComponentName = keyof typeof Components;
 

--- a/packages/svelte-ux/src/lib/plugins/tailwind/theme.cjs
+++ b/packages/svelte-ux/src/lib/plugins/tailwind/theme.cjs
@@ -1,6 +1,6 @@
 const colors = require('tailwindcss/colors');
 const { createThemeColors, processThemeColors } = require('../../styles/theme');
-const { entries } = require('../../types/typeHelpers.js');
+const { entries } = require('../../types/typeHelpers');
 
 const defaultThemes = {
   light: {

--- a/packages/svelte-ux/src/lib/plugins/tailwind/theme.cjs
+++ b/packages/svelte-ux/src/lib/plugins/tailwind/theme.cjs
@@ -1,5 +1,6 @@
 const colors = require('tailwindcss/colors');
 const { createThemeColors, processThemeColors } = require('../../styles/theme');
+const { entries } = require('../../types/typeHelpers.js');
 
 const defaultThemes = {
   light: {
@@ -32,7 +33,7 @@ function injectThemes(colorSpace, addBase, config) {
 
   const cssThemes = {};
   let rootThemeName = null;
-  Object.entries(themes).map(([themeName, themeColors], index) => {
+  entries(themes).map(([themeName, themeColors], index) => {
     if (index === 0) {
       // Root / default theme
       cssThemes[themeRoot] = processThemeColors(themeColors, colorSpace);

--- a/packages/svelte-ux/src/lib/stores/changeStore.ts
+++ b/packages/svelte-ux/src/lib/stores/changeStore.ts
@@ -1,5 +1,5 @@
 import { derived } from 'svelte/store';
-import type { Stores, StoresValues } from '$lib/types/index.js';
+import type { Stores, StoresValues } from '../types/index.js';
 
 function changeStore<T extends Stores>(
   store: T,

--- a/packages/svelte-ux/src/lib/stores/changeStore.ts
+++ b/packages/svelte-ux/src/lib/stores/changeStore.ts
@@ -1,5 +1,5 @@
 import { derived } from 'svelte/store';
-import type { Stores, StoresValues } from '../types/index.js';
+import type { Stores, StoresValues } from '../types/typeHelpers.js';
 
 function changeStore<T extends Stores>(
   store: T,

--- a/packages/svelte-ux/src/lib/stores/debounceStore.ts
+++ b/packages/svelte-ux/src/lib/stores/debounceStore.ts
@@ -1,5 +1,5 @@
 import { derived, get } from 'svelte/store';
-import type { Stores } from '$lib/types/index.js';
+import type { Stores } from '../types/index.js';
 
 function debounceStore<T extends Stores>(original: T, timeout = 300) {
   return derived(

--- a/packages/svelte-ux/src/lib/stores/debounceStore.ts
+++ b/packages/svelte-ux/src/lib/stores/debounceStore.ts
@@ -1,5 +1,5 @@
 import { derived, get } from 'svelte/store';
-import type { Stores } from '../types/index.js';
+import type { Stores } from '../types/typeHelpers.js';
 
 function debounceStore<T extends Stores>(original: T, timeout = 300) {
   return derived(

--- a/packages/svelte-ux/src/lib/stores/graphStore.ts
+++ b/packages/svelte-ux/src/lib/stores/graphStore.ts
@@ -4,7 +4,7 @@ import { merge } from 'lodash-es';
 
 import fetchStore, { initFetchClient } from './fetchStore.js';
 import type { FetchConfig } from './fetchStore.js';
-import { parse, stringify } from '$lib/utils/json.js';
+import { parse, stringify } from '../utils/json.js';
 
 type ClientConfig = {
   url: string;

--- a/packages/svelte-ux/src/lib/stores/queryParamsStore.ts
+++ b/packages/svelte-ux/src/lib/stores/queryParamsStore.ts
@@ -6,7 +6,7 @@ import { isEqual } from 'lodash-es';
 import * as Serialize from '../utils/serialize.js';
 
 import rollup from '../utils/rollup.js';
-import type { ValueOf } from '../types/typeHelpers.js';
+import { entries, type ValueOf } from '../types/typeHelpers.js';
 
 // Matches $app/navigation's goto without dependency - https://kit.svelte.dev/docs/modules#$app-navigation-goto
 type Goto = (url: string | URL, opts?: any) => any;
@@ -108,13 +108,13 @@ export function queryParamsStore<Values extends { [key: string]: any }>(
       const params = new URLSearchParams(); // queryParamsStore controls full params so start fresh
 
       if (newValues != null) {
-        Object.entries(newValues).forEach(([key, value]) => {
+        entries(newValues).forEach(([key, value]) => {
           const paramType =
             typeof props.paramTypes === 'function'
               ? props.paramTypes(key as string)
               : props.paramTypes?.[key as string];
 
-          applyParam(params, key, value, props.defaults?.[key], paramType);
+          applyParam(params, key as string, value, props.defaults?.[key], paramType);
         });
       }
 
@@ -229,18 +229,4 @@ export function getParamConfig(paramType: ParamType) {
     default:
       throw new Error('No param config found');
   }
-}
-
-/**
- *
- * @param params
- * @returns
- */
-function stringify(params: URLSearchParams) {
-  // Use `encodeURIComponent` instead of `params.toString()` as is more lenient (doesn't encode `(` or `)` where are used )
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
-  // https://stackoverflow.com/a/62969380/191902
-  return Object.entries(params)
-    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
-    .join('&');
 }

--- a/packages/svelte-ux/src/lib/styles/daisy.ts
+++ b/packages/svelte-ux/src/lib/styles/daisy.ts
@@ -57,7 +57,7 @@ function mapColorsName(themes: typeof daisyThemes, colorMap: typeof daisyColorMa
 
   return fromEntries(
     entries(themesGeneric)
-      .map(([themeName, colors]) : [string | Theme, Record<string, string>] => {
+      .map(([themeName, colors]): [string | Theme, Record<string, string>] => {
         const mappedColors = fromEntries(
           entries(colors).map(([key, value]): [string, string] => {
             return [colorMapGeneric[key] ?? key, value];
@@ -68,7 +68,6 @@ function mapColorsName(themes: typeof daisyThemes, colorMap: typeof daisyColorMa
       .sort(sortFunc(([themeName]) => themeNames.indexOf(themeName as string)))
   );
 }
-
 
 const themes = mapColorsName(daisyThemes, daisyColorMap);
 

--- a/packages/svelte-ux/src/lib/styles/daisy.ts
+++ b/packages/svelte-ux/src/lib/styles/daisy.ts
@@ -1,6 +1,8 @@
 import daisyThemes from 'daisyui/src/theming/themes.js';
 // import { themeOrder } from 'daisyui/src/theming/themeDefaults'; // breaks build
 import { sortFunc } from '../utils/sort.js';
+import { entries, fromEntries } from '$lib/types/typeHelpers.js';
+import type { Theme } from 'daisyui';
 
 const themeNames = [
   'light',
@@ -50,21 +52,23 @@ const daisyColorMap = {
  *  Map Daisy UI color names to Svelte UX names, and sort themes
  */
 function mapColorsName(themes: typeof daisyThemes, colorMap: typeof daisyColorMap) {
-  return Object.fromEntries(
-    Object.entries(themes)
-      .map(([themeName, colors]) => {
-        return [
-          themeName,
-          Object.fromEntries(
-            Object.entries(colors).map(([key, value]) => {
-              return [colorMap[key] ?? key, value];
-            })
-          ),
-        ];
+  let themesGeneric = themes as unknown as Record<Theme, Record<string, string>>;
+  let colorMapGeneric: Record<string, string> = colorMap;
+
+  return fromEntries(
+    entries(themesGeneric)
+      .map(([themeName, colors]) : [string | Theme, Record<string, string>] => {
+        const mappedColors = fromEntries(
+          entries(colors).map(([key, value]): [string, string] => {
+            return [colorMapGeneric[key] ?? key, value];
+          })
+        );
+        return [themeName, mappedColors];
       })
-      .sort(sortFunc(([themeName]) => themeNames.indexOf(themeName)))
+      .sort(sortFunc(([themeName]) => themeNames.indexOf(themeName as string)))
   );
 }
+
 
 const themes = mapColorsName(daisyThemes, daisyColorMap);
 

--- a/packages/svelte-ux/src/lib/styles/daisy.ts
+++ b/packages/svelte-ux/src/lib/styles/daisy.ts
@@ -1,7 +1,7 @@
 import daisyThemes from 'daisyui/src/theming/themes.js';
 // import { themeOrder } from 'daisyui/src/theming/themeDefaults'; // breaks build
 import { sortFunc } from '../utils/sort.js';
-import { entries, fromEntries } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries } from '../types/typeHelpers.js';
 import type { Theme } from 'daisyui';
 
 const themeNames = [

--- a/packages/svelte-ux/src/lib/styles/skeleton.ts
+++ b/packages/svelte-ux/src/lib/styles/skeleton.ts
@@ -11,7 +11,7 @@
 //
 // https://github.com/skeletonlabs/skeleton/blob/dev/packages/plugin/src/tailwind/themes/index.ts#L17-L19
 // import { getThemeProperties } from '@skeletonlabs/tw-plugin';
-import { entries, fromEntries } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries } from '../types/typeHelpers.js';
 import { getThemeProperties } from './skeleton/index.js';
 
 const themeNames = [

--- a/packages/svelte-ux/src/lib/styles/skeleton.ts
+++ b/packages/svelte-ux/src/lib/styles/skeleton.ts
@@ -41,7 +41,10 @@ const skeletonColorMap = {
   surface: 'surface',
 };
 
-function processTheme(themeName: (typeof themeNames)[number], scheme: 'light' | 'dark'): [string, Record<string, string>] {
+function processTheme(
+  themeName: (typeof themeNames)[number],
+  scheme: 'light' | 'dark'
+): [string, Record<string, string>] {
   const properties = getThemeProperties(themeName);
 
   let mappedThemeProperties: [string, string][] = entries(properties)
@@ -54,7 +57,10 @@ function processTheme(themeName: (typeof themeNames)[number], scheme: 'light' | 
         const skeletonColorShade = matches?.[2];
         const themeColorName = skeletonColorName && skeletonColorMap[skeletonColorName];
         if (themeColorName) {
-          return [`${themeColorName}-${skeletonColorShade}`, `rgb(${value})`] satisfies [string, string];
+          return [`${themeColorName}-${skeletonColorShade}`, `rgb(${value})`] satisfies [
+            string,
+            string,
+          ];
         }
       } else if (key.startsWith('--on-')) {
         // `--on-primary` => `primary-content`

--- a/packages/svelte-ux/src/lib/styles/theme.ts
+++ b/packages/svelte-ux/src/lib/styles/theme.ts
@@ -119,9 +119,15 @@ export function processThemeColors(
         const referenceColor = colors[`${color}-${referenceShade}`] ?? colors[color];
 
         if (shade < 500) {
-          colors[shadeColorName] ??= lightenColor(referenceColor, (referenceShade - shade) / 1000) as string; // 100 == 0.1
+          colors[shadeColorName] ??= lightenColor(
+            referenceColor,
+            (referenceShade - shade) / 1000
+          ) as string; // 100 == 0.1
         } else if (shade > 500) {
-          colors[shadeColorName] ??= darkenColor(colors[color], (shade - referenceShade) / 1000) as string; // 100 == 0.1
+          colors[shadeColorName] ??= darkenColor(
+            colors[color],
+            (shade - referenceShade) / 1000
+          ) as string; // 100 == 0.1
         } else {
           colors[shadeColorName] ??= colors[color] as string;
         }
@@ -207,19 +213,19 @@ export function colorVariableValue(
 ) {
   try {
     if (colorSpace === 'rgb') {
-      const computedColor = typeof color === 'string' ? rgb(color) : color as Rgb;
+      const computedColor = typeof color === 'string' ? rgb(color) : (color as Rgb);
       if (computedColor) {
         const { r, g, b } = computedColor;
         return `${round(r * 255, decimals)} ${round(g * 255, decimals)} ${round(b * 255, decimals)}`;
       }
     } else if (colorSpace === 'hsl') {
-      const computedColor = typeof color === 'string' ? hsl(clampRgb(color)) : color as Hsl;
+      const computedColor = typeof color === 'string' ? hsl(clampRgb(color)) : (color as Hsl);
       if (computedColor) {
         const { h, s, l } = computedColor;
         return `${round(h ?? 0, decimals)} ${round(s * 100, decimals)}% ${round(l * 100, decimals)}%`;
       }
     } else if (colorSpace === 'oklch') {
-      const computedColor = typeof color === 'string' ? oklch(clampRgb(color)) : color as Oklch;
+      const computedColor = typeof color === 'string' ? oklch(clampRgb(color)) : (color as Oklch);
       if (computedColor) {
         const { l, c, h } = computedColor;
         return `${round(l, decimals)} ${round(c, decimals)} ${round(h ?? 0, decimals)}`;

--- a/packages/svelte-ux/src/lib/styles/theme.ts
+++ b/packages/svelte-ux/src/lib/styles/theme.ts
@@ -9,7 +9,11 @@ import {
   wcagContrast,
   formatCss,
   type Color,
+  type Hsl,
+  type Oklch,
+  type Rgb,
 } from 'culori';
+import { entries, fromEntries, keys } from '$lib/types/typeHelpers.js';
 
 export type SupportedColorSpace = 'rgb' | 'hsl' | 'oklch';
 
@@ -38,7 +42,7 @@ export const colorNames = [
  * Generate theme colors (ex. { primary: hsl(var(--color-primary) / <alpha-value>), ... })
  */
 export function createThemeColors(colorSpace: SupportedColorSpace) {
-  return Object.fromEntries(
+  return fromEntries(
     colorNames.map((color) => [color, `${colorSpace}(var(--color-${color}) / <alpha-value>)`])
   );
 }
@@ -50,7 +54,7 @@ export function getThemeNames(themes: Record<string, any>) {
   const light: string[] = [];
   const dark: string[] = [];
 
-  Object.entries(themes).map(([themeName, props]) => {
+  entries(themes).map(([themeName, props]) => {
     if (props['color-scheme'] === 'dark') {
       dark.push(themeName);
     } else {
@@ -98,9 +102,7 @@ export function processThemeColors(
       colors[color] = themeColors[`${color}-500`];
     }
 
-    if (!(`${color}-content` in colors)) {
-      colors[`${color}-content`] = foregroundColor(colors[color]);
-    }
+    colors[`${color}-content`] ??= foregroundColor(colors[color]) as string;
 
     // Generate color shades (ex. `primary-500`) if not defined.  Useful for Daisy but not Skeleton themes, for example
     for (const shade of shades) {
@@ -108,54 +110,37 @@ export function processThemeColors(
       if (!(shadeColorName in colors)) {
         // Find the next shade above (shade < 500) or below (shade > 500) and use as reference, if available
         const referenceShade =
-          Object.keys(colors)
-            .map((str) => {
-              const [c, s] = str.split('-');
+          keys(colors)
+            .map((key) => {
+              const [c, s] = String(key).split('-');
               return [c, Number(s)] as [string, number];
             })
             .find(([c, s]) => c === color && (s < 500 ? s > shade : s < shade))?.[1] ?? 500;
         const referenceColor = colors[`${color}-${referenceShade}`] ?? colors[color];
 
         if (shade < 500) {
-          colors[shadeColorName] = lightenColor(referenceColor, (referenceShade - shade) / 1000); // 100 == 0.1
+          colors[shadeColorName] ??= lightenColor(referenceColor, (referenceShade - shade) / 1000) as string; // 100 == 0.1
         } else if (shade > 500) {
-          colors[shadeColorName] = darkenColor(colors[color], (shade - referenceShade) / 1000); // 100 == 0.1
+          colors[shadeColorName] ??= darkenColor(colors[color], (shade - referenceShade) / 1000) as string; // 100 == 0.1
         } else {
-          colors[shadeColorName] = colors[color];
+          colors[shadeColorName] ??= colors[color] as string;
         }
       }
     }
   }
 
   // Generate optional surface colors
-  if (!('surface-100' in colors)) {
-    colors['surface-100'] = 'oklch(100 0 0)';
-  }
-
-  if (!('surface-200' in colors)) {
-    colors['surface-200'] = darkenColor(colors['surface-100'], 0.07);
-  }
-
-  if (!('surface-300' in colors)) {
-    if ('surface-200' in themeColors) {
-      colors['surface-300'] = darkenColor(colors['surface-200'], 0.07);
-    } else {
-      colors['surface-300'] = darkenColor(colors['surface-100'], 0.14);
-    }
-  }
-
-  if (!('surface-content' in colors)) {
-    colors['surface-content'] = foregroundColor(colors['surface-100']);
-  }
+  colors['surface-100'] ??= 'oklch(100 0 0)';
+  colors['surface-200'] ??= darkenColor(colors['surface-100'], 0.07) as string;
+  colors['surface-300'] ??= darkenColor(colors['surface-200'], 0.07) as string;
+  colors['surface-content'] ??= foregroundColor(colors['surface-100']) as string;
 
   // Add `color-scheme: "dark"` for `dark` theme (if not set)
-  if (!('color-scheme' in colors)) {
-    colors['color-scheme'] = isDark(colors['surface-content']) ? 'light' : 'dark';
-  }
+  colors['color-scheme'] ??= isDark(colors['surface-content']) ? 'light' : 'dark';
 
-  const result = Object.fromEntries(
-    Object.entries(colors).map(([name, value]) => {
-      if (colorNames.includes(name)) {
+  const result = fromEntries(
+    entries(colors).map(([name, value]) => {
+      if (colorNames.includes(String(name))) {
         // Add space separated color variables for each color
         return [`--color-${name}`, colorVariableValue(value, colorSpace)];
       } else {
@@ -222,14 +207,23 @@ export function colorVariableValue(
 ) {
   try {
     if (colorSpace === 'rgb') {
-      const { r, g, b } = rgb(color);
-      return `${round(r * 255, decimals)} ${round(g * 255, decimals)} ${round(b * 255, decimals)}`;
+      const computedColor = typeof color === 'string' ? rgb(color) : color as Rgb;
+      if (computedColor) {
+        const { r, g, b } = computedColor;
+        return `${round(r * 255, decimals)} ${round(g * 255, decimals)} ${round(b * 255, decimals)}`;
+      }
     } else if (colorSpace === 'hsl') {
-      const { h, s, l } = hsl(clampRgb(color));
-      return `${round(h, decimals)} ${round(s * 100, decimals)}% ${round(l * 100, decimals)}%`;
+      const computedColor = typeof color === 'string' ? hsl(clampRgb(color)) : color as Hsl;
+      if (computedColor) {
+        const { h, s, l } = computedColor;
+        return `${round(h ?? 0, decimals)} ${round(s * 100, decimals)}% ${round(l * 100, decimals)}%`;
+      }
     } else if (colorSpace === 'oklch') {
-      const { l, c, h } = oklch(color);
-      return `${round(l, decimals)} ${round(c, decimals)} ${round(h, decimals)}`;
+      const computedColor = typeof color === 'string' ? oklch(clampRgb(color)) : color as Oklch;
+      if (computedColor) {
+        const { l, c, h } = computedColor;
+        return `${round(l, decimals)} ${round(c, decimals)} ${round(h ?? 0, decimals)}`;
+      }
     }
   } catch (e) {
     // console.error('Unable to convert color object to string', color);
@@ -241,7 +235,7 @@ export function colorVariableValue(
  */
 export function themeStylesString(theme: any, colorSpace: SupportedColorSpace) {
   const styleProperties = processThemeColors(theme, colorSpace);
-  return Object.entries(styleProperties)
+  return entries(styleProperties)
     .map(([key, value]) => {
       return `${key}: ${value};`;
     })
@@ -255,7 +249,7 @@ export function themeStylesString(theme: any, colorSpace: SupportedColorSpace) {
  * but it's the only way to inject the `darkThemes` array into the function.
  **/
 export function createHeadSnippet(darkThemes: string[]) {
-  function _applyInitialStyle(darkThemes) {
+  function _applyInitialStyle(darkThemes: string[]) {
     let theme = localStorage.getItem('theme');
     // Ignore if no dark things registered (default `dark` removed)
     if (darkThemes.length > 0) {

--- a/packages/svelte-ux/src/lib/styles/theme.ts
+++ b/packages/svelte-ux/src/lib/styles/theme.ts
@@ -13,7 +13,7 @@ import {
   type Oklch,
   type Rgb,
 } from 'culori';
-import { entries, fromEntries, keys } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries, keys } from '../types/typeHelpers.js';
 
 export type SupportedColorSpace = 'rgb' | 'hsl' | 'oklch';
 

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -1,6 +1,6 @@
 // https://basarat.gitbooks.io/typescript/docs/types/never.html#use-case-exhaustive-checks
 
-import type { colors } from '$lib/styles/theme.js';
+import type { colors } from '../styles/theme.js';
 import type { SvelteComponent } from 'svelte';
 import type { derived, Readable } from 'svelte/store';
 import type {

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -44,8 +44,8 @@ export type ObjectKey = string | number | symbol;
 export function entries<K extends ObjectKey, V>(o: Record<K, V>): [K, V][];
 export function entries<K, V>(o: Map<K, V>): [K, V][];
 export function entries<K extends ObjectKey | unknown, V>(o: Record<K, V> | Map<K, V>): [K, V][] {
-    if (o instanceof Map) return Array.from(o.entries()) as unknown as [K, V][];
-    return Object.entries(o) as unknown as [K, V][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
+  if (o instanceof Map) return Array.from(o.entries()) as unknown as [K, V][];
+  return Object.entries(o) as unknown as [K, V][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
 }
 
 // Get object from entries (array of [key, value] arrays) (strongly-typed)

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -38,19 +38,24 @@ export function keys<T extends object>(o: T) {
 }
 // export const keys = Object.keys as <T>(obj: T) => (Extract<keyof T, string>)[];
 
+export type ObjectKey = string | number | symbol;
+
 // Get entries (array of [key, value] arrays) of object (strongly-typed)
-export function entries<T extends object>(o: T) {
-  return Object.entries(o) as [keyof T, T[keyof T]][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
+export function entries<K extends ObjectKey, V>(o: Record<K, V>): [K, V][];
+export function entries<K, V>(o: Map<K, V>): [K, V][];
+export function entries<K extends ObjectKey | unknown, V>(o: Record<K, V> | Map<K, V>): [K, V][] {
+    if (o instanceof Map) return Array.from(o.entries()) as unknown as [K, V][];
+    return Object.entries(o) as unknown as [K, V][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
 }
 
 // Get object from entries (array of [key, value] arrays) (strongly-typed)
-export function fromEntries<K extends string, V>(entries: [K, V][]): Record<K, V> {
+export function fromEntries<K extends ObjectKey, V>(entries: [K, V][] | Map<K, V>): Record<K, V> {
   return Object.fromEntries(entries) as Record<K, V>;
 }
 
 // https://github.com/Microsoft/TypeScript/issues/17198#issuecomment-315400819
 export function enumKeys(E: any) {
-  return Object.keys(E).filter((k) => typeof E[k as any] === 'number'); // ["A", "B"]
+  return keys(E).filter((k) => typeof E[k as any] === 'number'); // ["A", "B"]
 }
 export function enumValues(E: any) {
   const keys = enumKeys(E);

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -1,7 +1,7 @@
 // https://basarat.gitbooks.io/typescript/docs/types/never.html#use-case-exhaustive-checks
 
 import type { colors } from '../styles/theme.js';
-import type { SvelteComponent } from 'svelte';
+import type { ComponentProps as SvelteComponentProps, SvelteComponent } from 'svelte';
 import type { derived, Readable } from 'svelte/store';
 import type {
   FlyParams,
@@ -89,8 +89,18 @@ export type FilterPropKeys<T, Match> = {
   [P in keyof T]: T[P] extends Match ? P : never;
 }[keyof T];
 
-// https://stackoverflow.com/a/72297256/191902
-export type ComponentProps<T> = T extends SvelteComponent<infer P, any, any> ? P : never;
+/**
+ * @deprecated ComponentProps should be imported from 'svelte' instead of 'svelte-ux', as it is now included in the main 'svelte' package. This export may be removed in a future release.
+ * @see https://svelte.dev/docs/svelte#types-componentprops
+ * @example
+ * ```ts
+ * import { ComponentProps } from 'svelte';
+ * import MyComponent from './MyComponent.svelte';
+ *
+ * type MyComponentProps = ComponentProps<typeof MyComponent>;
+ * ```
+ */
+export type ComponentProps<T extends SvelteComponent> = SvelteComponentProps<T>;
 export type ComponentEvents<T> = T extends SvelteComponent<any, infer E, any> ? E : never;
 export type ComponentSlots<T> = T extends SvelteComponent<any, any, infer S> ? S : never;
 

--- a/packages/svelte-ux/src/lib/utils/array.ts
+++ b/packages/svelte-ux/src/lib/utils/array.ts
@@ -2,6 +2,7 @@ import { greatest, rollup } from 'd3-array';
 
 import { propAccessor } from './object.js';
 import type { PropAccessorArg } from './object.js';
+import { entries, fromEntries } from '$lib/types/typeHelpers.js';
 
 // Helper until Array.flat is more mainstream - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat
 // See also: https://lodash.com/docs/4.17.11#flatten
@@ -38,9 +39,9 @@ export function sum(items: (object | null)[], prop?: PropAccessorArg) {
  * Sum array of objects by property
  */
 export function sumObjects(items: (object | null)[]) {
-  return Object.fromEntries(
+  return fromEntries(
     rollup(
-      items.flatMap((x) => Object.entries(x ?? {})),
+      items.flatMap((x) => entries(x ?? {})),
       (values) => sum(values, (d) => (Number.isFinite(d[1]) ? d[1] : 0)),
       (d) => d[0]
     )

--- a/packages/svelte-ux/src/lib/utils/array.ts
+++ b/packages/svelte-ux/src/lib/utils/array.ts
@@ -2,7 +2,7 @@ import { greatest, rollup } from 'd3-array';
 
 import { propAccessor } from './object.js';
 import type { PropAccessorArg } from './object.js';
-import { entries, fromEntries } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries } from '../types/typeHelpers.js';
 
 // Helper until Array.flat is more mainstream - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat
 // See also: https://lodash.com/docs/4.17.11#flatten

--- a/packages/svelte-ux/src/lib/utils/date.ts
+++ b/packages/svelte-ux/src/lib/utils/date.ts
@@ -42,7 +42,7 @@ import {
   type DateFormatVariantPreset,
 } from './date_types.js';
 import { defaultLocale, type LocaleSettings } from './locale.js';
-import { assertNever, entries } from '$lib/types/typeHelpers.js';
+import { assertNever, entries } from '../types/typeHelpers.js';
 
 export * from './date_types.js';
 

--- a/packages/svelte-ux/src/lib/utils/date.ts
+++ b/packages/svelte-ux/src/lib/utils/date.ts
@@ -42,7 +42,7 @@ import {
   type DateFormatVariantPreset,
 } from './date_types.js';
 import { defaultLocale, type LocaleSettings } from './locale.js';
-import { assertNever } from '$lib/types/typeHelpers.js';
+import { assertNever, entries } from '$lib/types/typeHelpers.js';
 
 export * from './date_types.js';
 
@@ -188,8 +188,8 @@ export function getPeriodTypeCode(periodType: PeriodType): string {
 }
 
 export function getPeriodTypeByCode(code: string): PeriodType {
-  const element = Object.entries(periodTypeMappings).find((c) => c[1] === code);
-  return parseInt(element?.[0] ?? '1');
+  const element = entries(periodTypeMappings).find((c) => c[1] === code);
+  return parseInt(String(element?.[0] ?? '1'));
 }
 
 export function getDayOfWeek(periodType: PeriodType): DayOfWeek | null {

--- a/packages/svelte-ux/src/lib/utils/excel.ts
+++ b/packages/svelte-ux/src/lib/utils/excel.ts
@@ -1,5 +1,5 @@
 // import { getCellContent, getCellValue, getHeaders, getRowColumns } from './table.js';
-// import type { ColumnDef } from '$lib/types/table.js';
+// import type { ColumnDef } from '../types/table.js';
 // import { PeriodType } from './date.js';
 // import { saveAs } from './file';
 // import { isLiteralObject } from './object.js';

--- a/packages/svelte-ux/src/lib/utils/icons.ts
+++ b/packages/svelte-ux/src/lib/utils/icons.ts
@@ -1,5 +1,5 @@
 import type { ComponentProps } from 'svelte';
-import type { default as Icon } from '$lib/components/Icon.svelte';
+import type { default as Icon } from '../components/Icon.svelte';
 import { isLiteralObject } from './object.js';
 
 export type IconInput = ComponentProps<Icon>['data'] | ComponentProps<Icon>;

--- a/packages/svelte-ux/src/lib/utils/locale.ts
+++ b/packages/svelte-ux/src/lib/utils/locale.ts
@@ -1,4 +1,4 @@
-import type { Prettify } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries, type Prettify } from '$lib/types/typeHelpers.js';
 import { defaultsDeep } from 'lodash-es';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import {
@@ -256,7 +256,7 @@ export function getAllKnownLocales(
   additionalLocales?: Record<string, LocaleSettingsInput>
 ): Record<string, LocaleSettings> {
   const additional = additionalLocales
-    ? Object.entries(additionalLocales).map(([key, value]) => [key, createLocaleSettings(value)])
+    ? entries(additionalLocales).map(([key, value]) => [key, createLocaleSettings(value)] satisfies [string, LocaleSettings])
     : [];
-  return { en: defaultLocale, ...Object.fromEntries(additional) };
+  return { en: defaultLocale, ...fromEntries(additional) };
 }

--- a/packages/svelte-ux/src/lib/utils/locale.ts
+++ b/packages/svelte-ux/src/lib/utils/locale.ts
@@ -256,7 +256,9 @@ export function getAllKnownLocales(
   additionalLocales?: Record<string, LocaleSettingsInput>
 ): Record<string, LocaleSettings> {
   const additional = additionalLocales
-    ? entries(additionalLocales).map(([key, value]) => [key, createLocaleSettings(value)] satisfies [string, LocaleSettings])
+    ? entries(additionalLocales).map(
+        ([key, value]) => [key, createLocaleSettings(value)] satisfies [string, LocaleSettings]
+      )
     : [];
   return { en: defaultLocale, ...fromEntries(additional) };
 }

--- a/packages/svelte-ux/src/lib/utils/locale.ts
+++ b/packages/svelte-ux/src/lib/utils/locale.ts
@@ -1,4 +1,4 @@
-import { entries, fromEntries, type Prettify } from '$lib/types/typeHelpers.js';
+import { entries, fromEntries, type Prettify } from '../types/typeHelpers.js';
 import { defaultsDeep } from 'lodash-es';
 import { derived, writable, type Readable, type Writable } from 'svelte/store';
 import {

--- a/packages/svelte-ux/src/lib/utils/object.ts
+++ b/packages/svelte-ux/src/lib/utils/object.ts
@@ -1,16 +1,16 @@
 import { get, camelCase, mergeWith } from 'lodash-es';
-import { entries } from '../types/typeHelpers.js';
+import { entries, fromEntries, keys } from '../types/typeHelpers.js';
 
 export function isLiteralObject(obj: any): obj is object {
   return obj && typeof obj === 'object' && obj.constructor === Object;
 }
 
 export function isEmptyObject(obj: any) {
-  return isLiteralObject(obj) && Object.keys(obj).length === 0;
+  return isLiteralObject(obj) && keys(obj).length === 0;
 }
 
 export function camelCaseKeys(obj: any) {
-  return Object.keys(obj).reduce((acc, key) => ((acc[camelCase(key)] = obj[key]), acc), {} as any);
+  return keys(obj).reduce((acc, key) => ((acc[camelCase(key ? String(key) : undefined)] = obj[key]), acc), {} as any);
 }
 
 // https://codereview.stackexchange.com/questions/73714/find-a-nested-property-in-an-object
@@ -58,8 +58,7 @@ export function objectId(object: any) {
 }
 
 export function distinctKeys(...objs: object[]) {
-  const keys: string[] = [...new Set(flatten(objs.map((x: object) => Object.keys(x))))];
-  return keys;
+  return [...new Set(flatten(objs.map((x: object) => keys(x as Record<string, any>))))];
 }
 
 // Copied from `array.ts` to remove circular dependency
@@ -93,43 +92,48 @@ export function expireObject<TObject extends object>(
 ): Partial<TObject> | null {
   const now = new Date();
 
-  if (expiry instanceof Date && expiry < now) {
+  if (expiry instanceof Date) {
     // Expired
-    return null;
-  } else if (typeof expiry === 'object') {
-    for (let [prop, propExpiry] of Object.entries(expiry)) {
-      if (propExpiry instanceof Date) {
-        // Check if expired
-        if (propExpiry < now) {
-          if (prop === '$default') {
-            // Delete all properties which do not have explicit expiry to check
-            for (let objProp of Object.keys(object) as Array<keyof TObject>) {
-              if (!(objProp in expiry)) {
-                delete object[objProp];
-              }
-            }
+    if (expiry < now) {
+      return null;
+    }
+    // Not expired
+    return object;
+  }
 
-            // Remove expired `$default` property
-            // @ts-expect-error it's fine if the property doesn't exist in object
-            delete object[prop];
-          } else {
-            // Remove expired property
-            // @ts-expect-error it's fine if the property doesn't exist in object
-            delete object[prop];
+  // LoopIterate over the properties in `object`
+  for (let [prop, propExpiry] of entries(expiry)) {
+    if (propExpiry instanceof Date) {
+      // Check if expired
+      if (propExpiry < now) {
+        if (prop === '$default') {
+          // Delete all properties which do not have explicit expiry to check
+          for (let objProp of keys(object) as Array<keyof TObject>) {
+            if (!(objProp in expiry)) {
+              delete object[objProp];
+            }
           }
+
+          // Remove expired `$default` property
+          // @ts-expect-error it's fine if the property doesn't exist in object
+          delete object[prop];
         } else {
-          // Keep value
+          // Remove expired property
+          // @ts-expect-error it's fine if the property doesn't exist in object
+          delete object[prop];
         }
       } else {
-        // Check expiry for each property in object.  Skip if prop not in object (expiry only)
-        const value = object[prop as keyof TObject];
-        if (value && typeof value === 'object') {
-          expireObject(value, propExpiry);
+        // Keep value
+      }
+    } else {
+      // Check expiry for each property in object.  Skip if prop not in object (expiry only)
+      const value = object[prop as keyof TObject];
+      if (value && typeof value === 'object') {
+        expireObject(value, propExpiry);
 
-          // Remove property if empty object (all properties removed)
-          if (isEmptyObject(value)) {
-            delete object[prop as keyof TObject];
-          }
+        // Remove property if empty object (all properties removed)
+        if (isEmptyObject(value)) {
+          delete object[prop as keyof TObject];
         }
       }
     }
@@ -141,12 +145,12 @@ export function expireObject<TObject extends object>(
 /**
  * Remove properties from an object.  See also lodash `_.omit()`
  */
-export function omit<T extends object = {}>(obj: T, keys: string[]): Partial<T> {
+export function omit<T extends object = {}>(obj: T, keys: (keyof T)[]): Partial<T> {
   if (keys.length === 0) {
     return obj;
   } else {
-    return Object.fromEntries(
-      Object.entries(obj).filter(([key, value]) => !keys.includes(key))
+    return fromEntries(
+      entries(obj).filter(([key]: [keyof T, T[keyof T]]) => !keys.includes(key))
     ) as Partial<T>;
   }
 }
@@ -158,7 +162,7 @@ export function pick<T extends object = {}>(obj: T, keys: string[]): Partial<T> 
   if (keys.length === 0) {
     return obj;
   } else {
-    return Object.fromEntries(
+    return fromEntries(
       keys.filter((key) => key in obj).map((key) => [key, obj[key as keyof T]])
     ) as Partial<T>;
   }
@@ -167,6 +171,8 @@ export function pick<T extends object = {}>(obj: T, keys: string[]): Partial<T> 
 /**
  * Create new object with keys and values swapped.  Last value's key is used if duplicated
  */
-export function keysByValues<T extends object = {}>(obj: T) {
-  return Object.fromEntries(entries(obj).map(([key, value]) => [value, key]));
+export function keysByValues<T extends object>(obj: T): Record<string, keyof T> {
+  return fromEntries(
+    entries(obj).map(([key, value]) => [String(value), key])
+  );
 }

--- a/packages/svelte-ux/src/lib/utils/object.ts
+++ b/packages/svelte-ux/src/lib/utils/object.ts
@@ -10,7 +10,10 @@ export function isEmptyObject(obj: any) {
 }
 
 export function camelCaseKeys(obj: any) {
-  return keys(obj).reduce((acc, key) => ((acc[camelCase(key ? String(key) : undefined)] = obj[key]), acc), {} as any);
+  return keys(obj).reduce(
+    (acc, key) => ((acc[camelCase(key ? String(key) : undefined)] = obj[key]), acc),
+    {} as any
+  );
 }
 
 // https://codereview.stackexchange.com/questions/73714/find-a-nested-property-in-an-object
@@ -172,7 +175,5 @@ export function pick<T extends object = {}>(obj: T, keys: string[]): Partial<T> 
  * Create new object with keys and values swapped.  Last value's key is used if duplicated
  */
 export function keysByValues<T extends object>(obj: T): Record<string, keyof T> {
-  return fromEntries(
-    entries(obj).map(([key, value]) => [String(value), key])
-  );
+  return fromEntries(entries(obj).map(([key, value]) => [String(value), key]));
 }

--- a/packages/svelte-ux/src/lib/utils/serialize.ts
+++ b/packages/svelte-ux/src/lib/utils/serialize.ts
@@ -1,3 +1,4 @@
+import { keys } from '$lib/types/typeHelpers.js';
 import { parse, reviver, stringify } from './json.js';
 import { isEmptyObject } from './object.js';
 
@@ -460,7 +461,7 @@ export function encodeObject(
   if (obj == null) return obj; // null or undefined
   if (isEmptyObject(obj)) return ''; // {} case
 
-  return Object.keys(obj)
+  return keys(obj)
     .map((key) => {
       const value = encodeJson(obj[key]);
       return `${key}${keyValSeparator}${value}`;
@@ -545,7 +546,7 @@ export function decodeNumericObject(
 
   // convert to numbers
   const decodedNumberObj: { [key: string]: number | null | undefined } = {};
-  for (const key of Object.keys(decoded)) {
+  for (const key of keys(decoded)) {
     decodedNumberObj[key] = decodeNumber(decoded[key]);
   }
 

--- a/packages/svelte-ux/src/lib/utils/serialize.ts
+++ b/packages/svelte-ux/src/lib/utils/serialize.ts
@@ -1,4 +1,4 @@
-import { keys } from '$lib/types/typeHelpers.js';
+import { keys } from '../types/typeHelpers.js';
 import { parse, reviver, stringify } from './json.js';
 import { isEmptyObject } from './object.js';
 

--- a/packages/svelte-ux/src/lib/utils/string.ts
+++ b/packages/svelte-ux/src/lib/utils/string.ts
@@ -1,3 +1,5 @@
+import { entries } from "$lib/types/typeHelpers.js";
+
 /**
  * Check if str only contians upper case letters
  */
@@ -68,7 +70,7 @@ export function romanize(value: number) {
 
   let result = '';
 
-  for (let [numeral, numeralValue] of Object.entries(lookup)) {
+  for (let [numeral, numeralValue] of entries(lookup)) {
     while (value >= numeralValue) {
       result += numeral;
       value -= numeralValue;

--- a/packages/svelte-ux/src/lib/utils/string.ts
+++ b/packages/svelte-ux/src/lib/utils/string.ts
@@ -1,4 +1,4 @@
-import { entries } from "../types/typeHelpers.js";
+import { entries } from '../types/typeHelpers.js';
 
 /**
  * Check if str only contians upper case letters

--- a/packages/svelte-ux/src/lib/utils/string.ts
+++ b/packages/svelte-ux/src/lib/utils/string.ts
@@ -1,4 +1,4 @@
-import { entries } from "$lib/types/typeHelpers.js";
+import { entries } from "../types/typeHelpers.js";
 
 /**
  * Check if str only contians upper case letters

--- a/packages/svelte-ux/src/lib/utils/styles.ts
+++ b/packages/svelte-ux/src/lib/utils/styles.ts
@@ -1,12 +1,13 @@
 import clsx, { type ClassValue } from 'clsx';
 import { extendTailwindMerge } from 'tailwind-merge';
 import { range } from 'd3-array';
+import { entries } from '$lib/types/typeHelpers.js';
 
 /**
  * Convert object to style string
  */
 export function objectToString(styleObj: { [key: string]: string }) {
-  return Object.entries(styleObj)
+  return entries(styleObj)
     .map(([key, value]) => {
       if (value) {
         // Convert camelCase into kaboob-case (ex.  (transformOrigin => transform-origin))

--- a/packages/svelte-ux/src/lib/utils/styles.ts
+++ b/packages/svelte-ux/src/lib/utils/styles.ts
@@ -1,7 +1,7 @@
 import clsx, { type ClassValue } from 'clsx';
 import { extendTailwindMerge } from 'tailwind-merge';
 import { range } from 'd3-array';
-import { entries } from '$lib/types/typeHelpers.js';
+import { entries } from '../types/typeHelpers.js';
 
 /**
  * Convert object to style string

--- a/packages/svelte-ux/src/routes/+layout.svelte
+++ b/packages/svelte-ux/src/routes/+layout.svelte
@@ -26,6 +26,7 @@
   import LanguageSelect from '$lib/components/LanguageSelect.svelte';
 
   import './app.css';
+  import { entries } from '$lib/types/typeHelpers.js';
 
   export let data;
 
@@ -140,7 +141,7 @@
   });
 
   const groups = ['components', 'actions', 'stores', 'utils'];
-  const quickSearchOptions = Object.entries(
+  const quickSearchOptions = entries(
     import.meta.glob('./docs/**/+page.(md|svelte)', { query: '?raw', eager: true })
   )
     .flatMap(([file, source]) => {

--- a/packages/svelte-ux/src/routes/_NavMenu.svelte
+++ b/packages/svelte-ux/src/routes/_NavMenu.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import NavItem from '$lib/components/NavItem.svelte';
+  import { entries } from '$lib/types/typeHelpers.js';
   import { mdiCog, mdiFormatListBulleted, mdiHome, mdiPalette } from '@mdi/js';
 
   const components = {
@@ -112,7 +113,7 @@
 <NavItem text="Changelog" icon={mdiFormatListBulleted} currentUrl={$page.url} path="/changelog" />
 
 <h1>Components</h1>
-{#each Object.entries(components) as [header, items]}
+{#each entries(components) as [header, items]}
   <h2>{header}</h2>
   {#each items as item}
     {#if typeof item === 'object'}

--- a/packages/svelte-ux/src/routes/theme/+page.svelte
+++ b/packages/svelte-ux/src/routes/theme/+page.svelte
@@ -114,7 +114,10 @@
   $: showDarkTheme = $currentTheme.dark;
   $: selectedLightTheme = lightThemes.find((d) => d.value === selectedLightThemeValue)?.theme;
   $: selectedDarkTheme = darkThemes.find((d) => d.value === selectedDarkThemeValue)?.theme;
-  $: previewTheme = (showDarkTheme ? selectedDarkTheme : selectedLightTheme) as Record<string, string>;
+  $: previewTheme = (showDarkTheme ? selectedDarkTheme : selectedLightTheme) as Record<
+    string,
+    string
+  >;
 
   // Update site dark/light mode with preview for better experience (previewing and applying)
   $: currentTheme.setTheme(showDarkTheme ? 'dark' : 'light');

--- a/packages/svelte-ux/src/routes/theme/+page.svelte
+++ b/packages/svelte-ux/src/routes/theme/+page.svelte
@@ -20,7 +20,7 @@
     themeStylesString,
     type SupportedColorSpace,
   } from '$lib/styles/theme.js';
-  import type { MenuOption } from '$lib/types/index.js';
+  import { entries, fromEntries, type MenuOption } from '$lib/types/index.js';
   import ColorField from './ColorField.svelte';
   import { getSettings } from '$lib/components/settings.js';
 
@@ -114,7 +114,7 @@
   $: showDarkTheme = $currentTheme.dark;
   $: selectedLightTheme = lightThemes.find((d) => d.value === selectedLightThemeValue)?.theme;
   $: selectedDarkTheme = darkThemes.find((d) => d.value === selectedDarkThemeValue)?.theme;
-  $: previewTheme = showDarkTheme ? selectedDarkTheme : selectedLightTheme;
+  $: previewTheme = (showDarkTheme ? selectedDarkTheme : selectedLightTheme) as Record<string, string>;
 
   // Update site dark/light mode with preview for better experience (previewing and applying)
   $: currentTheme.setTheme(showDarkTheme ? 'dark' : 'light');
@@ -127,7 +127,7 @@
       secondary: selectedLightTheme?.secondary ?? selectedLightTheme?.['secondary-500'],
       accent: selectedLightTheme?.accent ?? selectedLightTheme?.['accent-500'],
       neutral: selectedLightTheme?.neutral ?? selectedLightTheme?.['neutral-500'],
-    };
+    } as Record<string, string>;
   }
   $: selectedLightTheme && updateCustomLightTheme();
 
@@ -139,7 +139,7 @@
       secondary: selectedDarkTheme?.secondary ?? selectedDarkTheme?.['secondary-500'],
       accent: selectedDarkTheme?.accent ?? selectedDarkTheme?.['accent-500'],
       neutral: selectedDarkTheme?.neutral ?? selectedDarkTheme?.['neutral-500'],
-    };
+    } as Record<string, string>;
   }
   $: selectedDarkTheme && updateCustomLDarkTheme();
 </script>
@@ -217,8 +217,8 @@
               on:click={() => {
                 const allThemes = {
                   ...data.themes.daisy,
-                  ...Object.fromEntries(
-                    Object.entries(data.themes.skeleton).map(([themeName, value]) => {
+                  ...fromEntries(
+                    entries(data.themes.skeleton).map(([themeName, value]) => {
                       return [
                         themeName === 'light'
                           ? 'skeleton-light'


### PR DESCRIPTION
This PR adds support for Map objects for use with the `entries` function, and makes use of the Object type helpers (keys, entries, fromEntries) in several places where it seemed appropriate, and improved some type safety in areas impacted by the change.