### PR TITLE
Fix: Make ScrollFadeOptions optional in `scrollFade` action

### DIFF
--- a/.changeset/brave-rats-camp.md
+++ b/.changeset/brave-rats-camp.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Fix: Make ScrollFadeOptions optional in `scrollFade` action

--- a/packages/svelte-ux/src/lib/actions/scroll.ts
+++ b/packages/svelte-ux/src/lib/actions/scroll.ts
@@ -169,7 +169,7 @@ type ScrollFadeOptions = {
   scrollRatio?: number;
 };
 
-export const scrollFade: Action<HTMLElement, ScrollFadeOptions> = (node, options) => {
+export const scrollFade: Action<HTMLElement, ScrollFadeOptions> = (node, options?) => {
   const length = options?.length ?? 50;
   const scrollRatio = options?.scrollRatio ?? 5;
 


### PR DESCRIPTION
What this fixes: TS error when using `use:scrollFade` without args:

![](https://github.com/techniq/svelte-ux/assets/5913254/8d2463c2-603e-4e08-987a-350a20f53492)

Current workaround

![](https://github.com/techniq/svelte-ux/assets/5913254/1ad54abc-ccc5-4850-8c29-23f5fbc01b42)