### PR TITLE
Add support for wildcard import paths

### DIFF
--- a/packages/svelte-ux/package.json
+++ b/packages/svelte-ux/package.json
@@ -78,11 +78,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "svelte": "./dist/index.js"
+      "svelte": "./dist/index.js",
+      "default": "./dist/*"
     },
     "./utils/*": {
       "types": "./dist/utils/*.d.ts",
-      "svelte": "./dist/utils/*.js"
+      "svelte": "./dist/utils/*.js",
+      "default": "./dist/utils/*"
     },
     "./plugins/*": "./dist/plugins/*",
     "./styles/*": "./dist/styles/*"


### PR DESCRIPTION
## ⚠️  Experimental

I am not sure if this works or not without testing this within another repo, but the general idea is fixing the issue where the def and type exports are seen as coming from different import paths (w/ vs. w/o `dist`):

```ts
import { sumObjects as _sumObjects } from 'svelte-ux/utils/array';
import type { sumObjects as SumObjects } from 'svelte-ux/dist/utils/array';

const sumObjects = _sumObjects as typeof SumObjects;
```

Whenever you find time to test this, I think this might help to resolve that issue. More of a theory based on the docs here:
https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-exports