### PR TITLE
Allow setting Menu transition configuration from `settings`

### DIFF
--- a/.changeset/tender-carpets-juggle.md
+++ b/.changeset/tender-carpets-juggle.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Add Menu `transition` and `transitionParams` customization to `settings`

--- a/packages/svelte-ux/src/lib/components/Menu.svelte
+++ b/packages/svelte-ux/src/lib/components/Menu.svelte
@@ -9,7 +9,7 @@
 
   import Popover from './Popover.svelte';
   import type { TransitionParams } from '../types/typeHelpers.js';
-  import { getComponentClasses } from './theme.js';
+  import { getComponentSettings } from './settings.js';
 
   const dispatch = createEventDispatcher();
 
@@ -21,10 +21,10 @@
   export let autoPlacement = false;
   export let resize: ComponentProps<Popover>['resize'] = false;
   export let disableTransition = false;
-  export let transition = disableTransition
-    ? (node: HTMLElement, params: TransitionParams) => ({}) as TransitionConfig
-    : slide;
-  export let transitionParams: TransitionParams = {};
+  export let transition:
+    | ((node: HTMLElement, params: TransitionParams) => TransitionConfig)
+    | undefined = undefined;
+  export let transitionParams: TransitionParams | undefined = undefined;
   export let explicitClose = false;
   export let moveFocus = true;
 
@@ -32,7 +32,15 @@
     root?: string;
     menu?: string;
   } = {};
-  const settingsClasses = getComponentClasses('Menu');
+  const { classes: settingsClasses, defaults } = getComponentSettings('Menu');
+
+  $: resolvedTransition =
+    transition ??
+    defaults.transition ??
+    (disableTransition
+      ? (node: HTMLElement, params: TransitionParams) => ({}) as TransitionConfig
+      : slide);
+  $: resolvedTransitionParams = transitionParams ?? defaults.transitionParams ?? {};
 
   export let menuItemsEl: HTMLMenuElement | undefined = undefined;
 
@@ -80,7 +88,7 @@
       // Do not allow event to reach Popover's on:mouseup (clickOutside)
       e.stopPropagation();
     }}
-    transition:transition={transitionParams}
+    transition:resolvedTransition={resolvedTransitionParams}
     use:focusMove={{ disabled: !moveFocus }}
   >
     <slot {close} />

--- a/packages/svelte-ux/src/lib/components/theme.ts
+++ b/packages/svelte-ux/src/lib/components/theme.ts
@@ -7,7 +7,9 @@ import type {
   ButtonSize,
   ButtonVariant,
   LabelPlacement,
+  TransitionParams,
 } from '../types/index.js';
+import type { TransitionConfig } from 'svelte/transition';
 
 export type ComponentName = keyof typeof Components;
 
@@ -58,6 +60,10 @@ interface ComponentDefaultProps {
     color?: ButtonColor;
     size?: ButtonSize;
     rounded?: ButtonRounded;
+  };
+  Menu?: {
+    transition?: (node: HTMLElement, params: TransitionParams) => TransitionConfig;
+    transitionParams?: TransitionParams;
   };
   MenuField?: {
     labelPlacement?: LabelPlacement;


### PR DESCRIPTION
Would probably be useful to add this for other components as well but that may require some additional prop drilldown I think. This is a good start to just customize everything that uses Menu, which I think will be the most common case.