### PR TITLE
Remove unneeded postcss-import load

### DIFF
--- a/packages/svelte-ux/postcss.config.cjs
+++ b/packages/svelte-ux/postcss.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
   plugins: {
-    'postcss-import': {},
     'tailwindcss/nesting': {},
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
The Neovim Svelte plugin was failing since it couldn't load postcss-import, referenced from the postcss config. 

Not sure why there weren't issues anywhere else, but it doesn't seem like anything is actually doing an `@import` and everything appears to build fine without it.