### PR TITLE
Add min/max/step support for Input/TextField/NumberStepper

### DIFF
--- a/.changeset/brown-crabs-camp.md
+++ b/.changeset/brown-crabs-camp.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Add `step()` number util which combines `round()` and `decimalCount()` to simplify handling floating point handling with stepping

--- a/.changeset/new-dingos-compare.md
+++ b/.changeset/new-dingos-compare.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+[TextField/Input] Add `min`/`max`/`step` support (for `integer` / `decimal` types)

--- a/.changeset/short-rivers-doubt.md
+++ b/.changeset/short-rivers-doubt.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+[NumberStepper] Add `step` support (to support `decimal` including HTML form validation)

--- a/packages/svelte-ux/src/lib/components/Input.svelte
+++ b/packages/svelte-ux/src/lib/components/Input.svelte
@@ -31,6 +31,19 @@
   export let required = false;
   export let disabled = false;
 
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min
+   */
+  export let min: number | undefined = undefined;
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max
+   */
+  export let max: number | undefined = undefined;
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#step
+   */
+  export let step: number | undefined = undefined;
+
   $: placeholder = placeholderProp ?? mask;
 
   const settingsClasses = getComponentClasses('Input');
@@ -104,8 +117,11 @@
 
 <input
   {id}
-  {value}
   {type}
+  {value}
+  {min}
+  {max}
+  {step}
   {inputmode}
   placeholder={isFocused && mask ? mask : placeholder}
   {required}

--- a/packages/svelte-ux/src/lib/components/NumberStepper.svelte
+++ b/packages/svelte-ux/src/lib/components/NumberStepper.svelte
@@ -7,10 +7,12 @@
   import { selectOnFocus } from '../actions/input.js';
   import { getComponentClasses } from './theme.js';
   import { cls } from '../utils/styles.js';
+  import { step as stepUtil } from '../utils/number.js';
 
   export let value: number = 0;
   export let min: number | undefined = undefined;
   export let max: number | undefined = undefined;
+  export let step = 1;
   let className: string | undefined = undefined;
   export { className as class };
 
@@ -24,6 +26,9 @@
 <TextField
   type="integer"
   bind:value
+  {min}
+  {max}
+  {step}
   align="center"
   class={cls('NumberStepper w-24', settingsClasses.root, className)}
   actions={(node) => [selectOnFocus(node)]}
@@ -32,7 +37,7 @@
   <div slot="prepend">
     <Button
       icon={mdiMinus}
-      on:click={() => (value -= 1)}
+      on:click={() => (value = stepUtil(value, -step))}
       size="sm"
       disabled={min != null && value <= min}
     />
@@ -40,7 +45,7 @@
   <div slot="append">
     <Button
       icon={mdiPlus}
-      on:click={() => (value += 1)}
+      on:click={() => (value = stepUtil(value, step))}
       size="sm"
       disabled={max != null && value >= max}
     />

--- a/packages/svelte-ux/src/lib/components/TextField.svelte
+++ b/packages/svelte-ux/src/lib/components/TextField.svelte
@@ -81,6 +81,19 @@
   export let autocapitalize: ComponentProps<Input>['autocapitalize'] = undefined;
   export let role: AriaRole | undefined = undefined;
 
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#min
+   */
+  export let min: number | undefined = undefined;
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#max
+   */
+  export let max: number | undefined = undefined;
+  /**
+   * see: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#step
+   */
+  export let step: number | undefined = type === 'decimal' ? 0.1 : 1;
+
   let inputType = 'text';
   $: switch (type) {
     case 'integer':
@@ -349,6 +362,9 @@
                 {replace}
                 {accept}
                 {autocapitalize}
+                {min}
+                {max}
+                {step}
                 {actions}
                 bind:inputEl
                 on:input={handleInput}

--- a/packages/svelte-ux/src/lib/utils/number.test.ts
+++ b/packages/svelte-ux/src/lib/utils/number.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
-import { clamp, formatNumber, formatNumberWithLocale, round } from './number.js';
-import { defaultLocale, createLocaleSettings } from './locale.js';
+import { clamp, formatNumber, formatNumberWithLocale, round, step } from './number.js';
+import { createLocaleSettings } from './locale.js';
 
 describe('clamp()', () => {
   it('no change', () => {
@@ -46,6 +46,48 @@ describe('round()', () => {
     const original = 123.456;
     const actual = round(original, 2);
     expect(actual).equal(123.46);
+  });
+});
+
+describe('step()', () => {
+  it('integer (step up)', () => {
+    const actual = step(2, 1);
+    expect(actual).equal(3);
+  });
+
+  it('integer (step down)', () => {
+    const actual = step(2, -1);
+    expect(actual).equal(1);
+  });
+
+  it('decimal (step up)', () => {
+    const actual = step(0.2, 0.1);
+    expect(actual).equal(0.3);
+  });
+
+  it('decimal (step down)', () => {
+    const actual = step(0.2, -0.1);
+    expect(actual).equal(0.1);
+  });
+
+  it('decimal with integer step (step up)', () => {
+    const actual = step(0.2, 1);
+    expect(actual).equal(1);
+  });
+
+  it('decimal with integer step (step down)', () => {
+    const actual = step(0.2, -1);
+    expect(actual).equal(-1);
+  });
+
+  it('integer with decimal step (step up)', () => {
+    const actual = step(2, 0.1);
+    expect(actual).equal(2.1);
+  });
+
+  it('integer with decimal step (step down)', () => {
+    const actual = step(2, -0.1);
+    expect(actual).equal(1.9);
   });
 });
 

--- a/packages/svelte-ux/src/lib/utils/number.ts
+++ b/packages/svelte-ux/src/lib/utils/number.ts
@@ -132,6 +132,13 @@ export function round(value: number, decimals: number) {
 }
 
 /**
+ * Step value while rounding to the nearest step precision (work around float issues such as `0.2` + `0.1`)
+ */
+export function step(value: number, step: number) {
+  return round(value + step, decimalCount(step));
+}
+
+/**
  * Get random number between min and max (inclusive).  See also d3.randomInt()
  */
 export function randomInteger(min: number, max: number) {

--- a/packages/svelte-ux/src/routes/docs/components/NumberStepper/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/NumberStepper/+page.svelte
@@ -37,3 +37,9 @@
 <Preview>
   <NumberStepper min={0} max={10} />
 </Preview>
+
+<h2>step</h2>
+
+<Preview>
+  <NumberStepper step={0.1} />
+</Preview>


### PR DESCRIPTION
Add `step()` number util which combines `round()` and `decimalCount()` to simplify handling floating point handling with stepping

[TextField/Input] Add `min`/`max`/`step` support (for `integer` / `decimal` types)

[NumberStepper] Add `step` support (to support `decimal` including HTML form validation)