### PR TITLE
Docs: Persist custom theme

### DIFF
--- a/packages/svelte-ux/src/routes/theme/+page.svelte
+++ b/packages/svelte-ux/src/routes/theme/+page.svelte
@@ -24,6 +24,7 @@
   } from '$lib/styles/theme.js';
   import { entries, fromEntries, type MenuOption } from '$lib/types/index.js';
   import ColorField from './ColorField.svelte';
+  import { formatColor } from './colors.js';
   import { getSettings } from '$lib/components/settings.js';
 
   export let data;
@@ -176,6 +177,33 @@
 
     // TODO: Update settings({ themes: { light: ['light'], dark: ['dark'] }})
   }
+
+  const themeKeys = [
+    { key: 'primary', label: 'Primary', optional: false },
+    { key: 'secondary', label: 'Secondary', optional: false },
+    { key: 'accent', label: 'Accent', optional: false },
+    { key: 'neutral', label: 'Neutral', optional: true },
+    { key: 'info', label: 'Info', optional: true },
+    { key: 'success', label: 'Success', optional: true },
+    { key: 'warning', label: 'Warning', optional: true },
+    { key: 'danger', label: 'Danger', optional: true },
+    { key: 'surface-100', label: 'Surface 100', optional: false },
+    { key: 'surface-200', label: 'Surface 200', optional: true },
+    { key: 'surface-300', label: 'Surface 300', optional: true },
+  ];
+
+  $: currentThemeSettings = themeKeys.reduce(
+    (acc, { key }) => {
+      if (customDarkTheme[key]) {
+        acc.dark[key] = formatColor(customDarkTheme[key], colorSpace);
+      }
+      if (customLightTheme[key]) {
+        acc.light[key] = formatColor(customLightTheme[key], colorSpace);
+      }
+      return acc;
+    },
+    { light: {}, dark: {} }
+  );
 </script>
 
 <main class="p-4 grid gap-5">
@@ -218,15 +246,25 @@
 
     <ButtonGroup variant="fill" color="primary">
       <Tooltip title="Copy themes to clipboard" offset={2}>
-        <CopyButton
-          value={JSON.stringify({ light: selectedLightTheme, dark: selectedDarkTheme }, null, 2)}
-        />
+        <CopyButton value={JSON.stringify(currentThemeSettings, null, 2)} />
       </Tooltip>
 
       <Toggle let:on={open} let:toggle>
         <div class="grid">
           <Button icon={mdiChevronDown} on:click={toggle} rounded class="px-1" />
           <Menu {open} on:close={toggle} placement="bottom-start">
+            <MenuItem
+              on:click={() => {
+                const value = JSON.stringify(
+                  { light: selectedLightTheme, dark: selectedDarkTheme },
+                  null,
+                  2
+                );
+                navigator.clipboard.writeText(value);
+              }}
+            >
+              Copy Full Theme
+            </MenuItem>
             <MenuItem
               on:click={() => {
                 const allThemes = {
@@ -275,222 +313,36 @@
   <div class="grid sm:grid-cols-2 gap-2">
     <div class="grid gap-2">
       <div class="text-xs -mb-1 text-surface-content/50 font-semibold">Light theme</div>
-      <ColorField
-        label="Primary"
-        bind:value={customLightTheme.primary}
-        on:change={() => {
-          selectedLightThemeValue = 'custom';
-          showDarkTheme = false;
-        }}
-        {colorSpace}
-      />
-      <ColorField
-        label="Secondary"
-        bind:value={customLightTheme.secondary}
-        on:change={() => {
-          selectedLightThemeValue = 'custom';
-          showDarkTheme = false;
-        }}
-        {colorSpace}
-      />
-      <ColorField
-        label="Accent"
-        bind:value={customLightTheme.accent}
-        on:change={() => {
-          selectedLightThemeValue = 'custom';
-          showDarkTheme = false;
-        }}
-        {colorSpace}
-      />
-
-      {#if showOptionalColors}
-        <ColorField
-          label="Neutral (optional)"
-          bind:value={customLightTheme.neutral}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-        <!-- State colors -->
-        <ColorField
-          label="Info (optional)"
-          bind:value={customLightTheme.info}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Success (optional)"
-          bind:value={customLightTheme.success}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Warning (optional)"
-          bind:value={customLightTheme.warning}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Danger (optional)"
-          bind:value={customLightTheme.danger}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-      {/if}
-
-      <ColorField
-        label="Surface 100"
-        bind:value={customLightTheme['surface-100']}
-        on:change={() => {
-          selectedLightThemeValue = 'custom';
-          showDarkTheme = false;
-        }}
-        {colorSpace}
-      />
-      {#if showOptionalColors}
-        <ColorField
-          label="Surface 200 (optional)"
-          bind:value={customLightTheme['surface-200']}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Surface 300 (optional)"
-          bind:value={customLightTheme['surface-300']}
-          on:change={() => {
-            selectedLightThemeValue = 'custom';
-            showDarkTheme = false;
-          }}
-          {colorSpace}
-        />
-      {/if}
+      {#each themeKeys as { key, label, optional }}
+        {#if showOptionalColors || !optional}
+          <ColorField
+            label={optional ? `${label} (optional)` : label}
+            bind:value={customLightTheme[key]}
+            on:change={() => {
+              selectedLightThemeValue = 'custom';
+              showDarkTheme = false;
+            }}
+            {colorSpace}
+          />
+        {/if}
+      {/each}
     </div>
 
     <div class="grid gap-2">
       <div class="text-xs -mb-1 text-surface-content/50 font-semibold">Dark theme</div>
-      <ColorField
-        label="Primary"
-        bind:value={customDarkTheme.primary}
-        on:change={() => {
-          selectedDarkThemeValue = 'custom';
-          showDarkTheme = true;
-        }}
-        {colorSpace}
-      />
-      <ColorField
-        label="Secondary"
-        bind:value={customDarkTheme.secondary}
-        on:change={() => {
-          selectedDarkThemeValue = 'custom';
-          showDarkTheme = true;
-        }}
-        {colorSpace}
-      />
-      <ColorField
-        label="Accent"
-        bind:value={customDarkTheme.accent}
-        on:change={() => {
-          selectedDarkThemeValue = 'custom';
-          showDarkTheme = true;
-        }}
-        {colorSpace}
-      />
-
-      {#if showOptionalColors}
-        <ColorField
-          label="Neutral (optional)"
-          bind:value={customDarkTheme.neutral}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-        <!-- State colors -->
-        <ColorField
-          label="Info (optional)"
-          bind:value={customDarkTheme.info}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Success (optional)"
-          bind:value={customDarkTheme.success}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Warning (optional)"
-          bind:value={customDarkTheme.warning}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Danger (optional)"
-          bind:value={customDarkTheme.danger}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-      {/if}
-
-      <ColorField
-        label="Surface 100"
-        bind:value={customDarkTheme['surface-100']}
-        on:change={() => {
-          selectedDarkThemeValue = 'custom';
-          showDarkTheme = true;
-        }}
-        {colorSpace}
-      />
-      {#if showOptionalColors}
-        <ColorField
-          label="Surface 200 (optional)"
-          bind:value={customDarkTheme['surface-200']}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-        <ColorField
-          label="Surface 300 (optional)"
-          bind:value={customDarkTheme['surface-300']}
-          on:change={() => {
-            selectedDarkThemeValue = 'custom';
-            showDarkTheme = true;
-          }}
-          {colorSpace}
-        />
-      {/if}
+      {#each themeKeys as { key, label, optional }}
+        {#if showOptionalColors || !optional}
+          <ColorField
+            label={optional ? `${label} (optional)` : label}
+            bind:value={customDarkTheme[key]}
+            on:change={() => {
+              selectedDarkThemeValue = 'custom';
+              showDarkTheme = true;
+            }}
+            {colorSpace}
+          />
+        {/if}
+      {/each}
     </div>
 
     <div>

--- a/packages/svelte-ux/src/routes/theme/ColorField.svelte
+++ b/packages/svelte-ux/src/routes/theme/ColorField.svelte
@@ -3,7 +3,8 @@
   import { formatHex } from 'culori';
 
   import TextField from '$lib/components/TextField.svelte';
-  import { colorVariableValue, type SupportedColorSpace } from '$lib/styles/theme.js';
+  import { formatColor } from './colors.js';
+  import { type SupportedColorSpace } from '$lib/styles/theme.js';
 
   const dispatch = createEventDispatcher<{
     change: { value: string | undefined };
@@ -13,32 +14,12 @@
 
   export let value: string;
   export let colorSpace: SupportedColorSpace | 'hex' = 'rgb';
-
-  function formatColor(value: string, colorSpace: SupportedColorSpace | 'hex') {
-    if (value) {
-      if (colorSpace === 'hex') {
-        // Only format if not already formatted.  Fixes `#123` becoming `#112233`
-        return value.startsWith('#') ? value : formatHex(value);
-      } else {
-        const colorValue = colorVariableValue(value, colorSpace);
-        if (colorValue) {
-          return `${colorSpace}(${colorValue})`;
-        } else {
-          // Return original if unable to convert (i.e invalid such as `rgb( 20 30)`)
-          return value;
-        }
-      }
-    } else {
-      return value;
-    }
-  }
 </script>
 
 <TextField
   value={formatColor(value, colorSpace)}
   on:change={(e) => {
     value = formatColor(e.detail.inputValue, colorSpace);
-    console.log(value, e.detail.inputValue);
     dispatch('change', { value });
   }}
   {...$$restProps}

--- a/packages/svelte-ux/src/routes/theme/colors.ts
+++ b/packages/svelte-ux/src/routes/theme/colors.ts
@@ -1,0 +1,21 @@
+import { colorVariableValue, type SupportedColorSpace } from '$lib/styles/theme.js';
+import { formatHex } from 'culori';
+
+export function formatColor(value: string, colorSpace: SupportedColorSpace | 'hex') {
+  if (value) {
+    if (colorSpace === 'hex') {
+      // Only format if not already formatted.  Fixes `#123` becoming `#112233`
+      return value.startsWith('#') ? value : formatHex(value);
+    } else {
+      const colorValue = colorVariableValue(value, colorSpace);
+      if (colorValue) {
+        return `${colorSpace}(${colorValue})`;
+      } else {
+        // Return original if unable to convert (i.e invalid such as `rgb( 20 30)`)
+        return value;
+      }
+    }
+  } else {
+    return value;
+  }
+}


### PR DESCRIPTION
This is stacked on top of #320 so currently includes changes from both.

This still needs a little more work, or we may want to drop this in favor of a better solution that addresses these pain points:

- The theme is saved, but when you reload the page custom themes are not applied unless you go back to the theme page and reenable preview. I think if we want to re-apply on startup it may require some higher-level integration of the custom theme.
- It now always says custom instead of the actual theme name... probably need to persist the selected theme value as well or something so we can reload that when it's not custom.

