### PR TITLE
Update `sumObjects` to coerce numeric strings, preserve Arrays in return

### DIFF
--- a/.changeset/friendly-experts-refuse.md
+++ b/.changeset/friendly-experts-refuse.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Update `sumObjects` to return the summed values as an Array if all processed items are arrays

--- a/.changeset/great-ads-try.md
+++ b/.changeset/great-ads-try.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Update `sumObjects` to automatically coerce numeric strings to numbers

--- a/packages/svelte-ux/src/lib/utils/array.test.ts
+++ b/packages/svelte-ux/src/lib/utils/array.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import { sumObjects } from './array.js';
+import { testDate } from './date.test.js';
 
 describe('sumObjects', () => {
   it('Sum array of objects ', () => {
@@ -10,7 +11,7 @@ describe('sumObjects', () => {
       { one: null, two: null, three: null, four: null },
       { one: NaN, two: NaN, three: NaN, four: NaN },
       { one: 'NaN', two: 'NaN', three: 'NaN', four: 'NaN' },
-      { one: '3', two: 6, four: '4', startDate: new Date('2024-04-05T20:58:04.000Z') },
+      { one: '3', two: 6, four: '4', startDate: new Date(testDate) },
     ];
 
     const actual = sumObjects(values);
@@ -20,7 +21,7 @@ describe('sumObjects', () => {
       three: 9,
       four: 4,
       extra: 0,
-      startDate: 1712350684000,
+      startDate: +new Date(testDate),
     };
 
     expect(actual).toEqual(expected);

--- a/packages/svelte-ux/src/lib/utils/array.test.ts
+++ b/packages/svelte-ux/src/lib/utils/array.test.ts
@@ -5,9 +5,12 @@ import { sumObjects } from './array.js';
 describe('sumObjects', () => {
   it('Sum array of objects ', () => {
     const values = [
-      { one: 1, two: 2, three: 3, extra: 'Hello' },
-      { one: 2, two: 4, three: 6 },
-      { one: 3, two: 6, four: 4, startDate: new Date() },
+      { one: 1, two: 2, three: '3', extra: 'Hello' },
+      { one: 2, two: '4', three: 6 },
+      { one: null, two: null, three: null, four: null },
+      { one: NaN, two: NaN, three: NaN, four: NaN },
+      { one: 'NaN', two: 'NaN', three: 'NaN', four: 'NaN' },
+      { one: '3', two: 6, four: '4', startDate: new Date('2024-04-05T20:58:04.000Z') },
     ];
 
     const actual = sumObjects(values);
@@ -17,7 +20,7 @@ describe('sumObjects', () => {
       three: 9,
       four: 4,
       extra: 0,
-      startDate: 0,
+      startDate: 1712350684000,
     };
 
     expect(actual).toEqual(expected);

--- a/packages/svelte-ux/src/lib/utils/array.ts
+++ b/packages/svelte-ux/src/lib/utils/array.ts
@@ -43,10 +43,11 @@ export function sumObjects(items: (object | null)[], prop?: PropAccessorArg) {
 
   const result = rollup(
     items.flatMap((x) => entries(x ?? {})),
-    (values) => sum(values, (d) => {
-      const value = Number(getProp(d[1]));
-      return Number.isFinite(value) ? value : 0;
-    }),
+    (values) =>
+      sum(values, (d) => {
+        const value = Number(getProp(d[1]));
+        return Number.isFinite(value) ? value : 0;
+      }),
     (d) => d[0]
   );
 

--- a/packages/svelte-ux/src/lib/utils/array.ts
+++ b/packages/svelte-ux/src/lib/utils/array.ts
@@ -38,14 +38,19 @@ export function sum(items: (object | null)[], prop?: PropAccessorArg) {
 /**
  * Sum array of objects by property
  */
-export function sumObjects(items: (object | null)[]) {
-  return fromEntries(
-    rollup(
-      items.flatMap((x) => entries(x ?? {})),
-      (values) => sum(values, (d) => (Number.isFinite(d[1]) ? d[1] : 0)),
-      (d) => d[0]
-    )
+export function sumObjects(items: (object | null)[], prop?: PropAccessorArg) {
+  const getProp = propAccessor(prop);
+
+  const result = rollup(
+    items.flatMap((x) => entries(x ?? {})),
+    (values) => sum(values, (d) => {
+      const value = Number(getProp(d[1]));
+      return Number.isFinite(value) ? value : 0;
+    }),
+    (d) => d[0]
   );
+
+  return items.every(item => Array.isArray(item)) ? Array.from(result.values()) : fromEntries(result);
 }
 
 /**

--- a/packages/svelte-ux/src/lib/utils/array.ts
+++ b/packages/svelte-ux/src/lib/utils/array.ts
@@ -50,7 +50,7 @@ export function sumObjects(items: (object | null)[], prop?: PropAccessorArg) {
     (d) => d[0]
   );
 
-  return items.every(item => Array.isArray(item)) ? Array.from(result.values()) : fromEntries(result);
+  return items.every(Array.isArray) ? Array.from(result.values()) : fromEntries(result);
 }
 
 /**


### PR DESCRIPTION
Changed made
- Update `sumObjects` to automatically coerce numeric strings to numbers
- Update `sumObjects` to return the summed values as an Array if all processed items are arrays