### PR TITLE
Add missing settingsClasses to Table.svelte

### DIFF
--- a/packages/svelte-ux/src/lib/components/Table.svelte
+++ b/packages/svelte-ux/src/lib/components/Table.svelte
@@ -12,6 +12,8 @@
   import { getSettings } from './settings.js';
   import tableOrderStore from '../stores/tableOrderStore.js';
 
+  const settingsClasses = getComponentClasses('Table');
+
   type T = $$Generic;
 
   const dispatch = createEventDispatcher<{


### PR DESCRIPTION
Table isnt stylable since the settingsClass isnt loaded. I noticed it in my own project, I dont know is its all changes needed.