### PR TITLE
Add default portal target setting

### DIFF
--- a/.changeset/eighty-starfishes-accept.md
+++ b/.changeset/eighty-starfishes-accept.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Add default portal target to setting

--- a/packages/svelte-ux/src/lib/actions/portal.ts
+++ b/packages/svelte-ux/src/lib/actions/portal.ts
@@ -1,4 +1,5 @@
 import type { Action } from 'svelte/action';
+import { getSettings } from '$lib/components/settings.js';
 
 export type PortalOptions =
   | {
@@ -11,14 +12,15 @@ export type PortalOptions =
  * Render component outside current DOM hierarchy
  */
 export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
-  moveNode(node, options);
+  const defaultTarget = getDefaultTarget();
+  moveNode(node, options, defaultTarget);
 
   return {
     update(options) {
-      moveNode(node, options);
+      moveNode(node, options, defaultTarget);
     },
     destroy() {
-      const target = getTarget(options);
+      const target = getTarget(options, defaultTarget);
       // If target still contains node that was moved, remove it.  Not sure if required
       if (target?.contains(node)) {
         target.removeChild(node);
@@ -27,21 +29,24 @@ export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
   };
 };
 
-function moveNode(node: HTMLElement, options: PortalOptions = {}) {
+function moveNode(node: HTMLElement, options: PortalOptions = {}, defaultTarget: HTMLElement | string) {
   const enabled = typeof options === 'boolean' ? options : options.enabled;
   if (enabled === false) return;
 
-  const target = getTarget(options);
+  const target = getTarget(options, defaultTarget);
   target?.appendChild(node);
 }
 
-function getTarget(options: PortalOptions = {}) {
-  const target = typeof options === 'object' ? options.target : undefined;
+function getTarget(options: PortalOptions = {}, defaultTarget: HTMLElement | string) {
+  const target = typeof options === 'object' ? options.target ?? defaultTarget : defaultTarget;
   if (target instanceof HTMLElement) {
     return target;
-  } else if (typeof target === 'string') {
-    return document.querySelector(target);
   } else {
-    return document.body;
+    return document.querySelector(target) ?? document.body;
   }
+}
+
+function getDefaultTarget(): HTMLElement | string  {
+  const settings = getSettings();
+  return settings.actions?.portal?.target ?? document.body;
 }

--- a/packages/svelte-ux/src/lib/components/settings.ts
+++ b/packages/svelte-ux/src/lib/components/settings.ts
@@ -22,6 +22,10 @@ export interface DefaultProps {
   labelPlacement: LabelPlacement;
 }
 
+type ActionSettings = {
+  portal?: { target: HTMLElement | string };
+}
+
 export type SettingsInput = {
   /** Force a specific locale setting. */
   forceLocale?: string;
@@ -32,6 +36,7 @@ export type SettingsInput = {
   localeFormats?: Record<string, LocaleSettingsInput>;
 
   components?: ComponentSettings;
+  actions?: ActionSettings;
   /** A list of the available themes */
   themes?: {
     light?: string[];

--- a/packages/svelte-ux/src/routes/docs/components/Settings/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Settings/+page.svelte
@@ -18,6 +18,9 @@
       Menu: { classes: 'shadow-xl border-gray-500' },
       MenuItem: { classes: 'font-bold' },
     }}
+    actions={{
+      portal: { target: '.portal-target' },
+    }}
   >
     <Toggle let:on={open} let:toggle>
       <Button on:click={toggle} variant="outline" color="primary">
@@ -32,4 +35,6 @@
       </Button>
     </Toggle>
   </Settings>
+
+  <div class="portal-target"></div>
 </Preview>


### PR DESCRIPTION
Seems to be working. I need this change in order to use svelte-ux in a shadow DOM/web component

![image](https://github.com/techniq/svelte-ux/assets/12587509/35e46bc0-484c-4114-be20-419cdc233577)
