### PR TITLE
Add well known PortalTarget class and examples

### DIFF
--- a/.changeset/fluffy-pans-accept.md
+++ b/.changeset/fluffy-pans-accept.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Add well known PortalTarget class and examples

--- a/packages/svelte-ux/src/lib/actions/portal.ts
+++ b/packages/svelte-ux/src/lib/actions/portal.ts
@@ -7,18 +7,29 @@ export type PortalOptions =
     }
   | boolean;
 
+type PortalTargets = {
+  fallbackTarget: Element | null;
+  originalParent: HTMLElement | null;
+};
+
 /**
  * Render component outside current DOM hierarchy
  */
 export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
-  moveNode(node, options);
+  const targets = {
+    // prefer ancestors, but it doesn't have to be an ancestor
+    fallbackTarget: node.closest('.PortalTarget') ?? document.querySelector('.PortalTarget'),
+    originalParent: node.parentElement,
+  };
+  moveNode(node, options, targets);
 
   return {
     update(options) {
-      moveNode(node, options);
+      console.log(options);
+      moveNode(node, options, targets);
     },
     destroy() {
-      const target = getTarget(options);
+      const target = getTarget(options, targets.fallbackTarget);
       // If target still contains node that was moved, remove it.  Not sure if required
       if (target?.contains(node)) {
         target.removeChild(node);
@@ -27,21 +38,27 @@ export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
   };
 };
 
-function moveNode(node: HTMLElement, options: PortalOptions = {}) {
+function moveNode(node: HTMLElement, options: PortalOptions = {}, targets: PortalTargets) {
   const enabled = typeof options === 'boolean' ? options : options.enabled;
-  if (enabled === false) return;
+  if (enabled === false) {
+    // Put it back where it came from
+    if (targets.originalParent !== node.parentElement) {
+      targets.originalParent?.appendChild(node);
+    }
+    return;
+  }
 
-  const target = getTarget(options);
+  const target = getTarget(options, targets.fallbackTarget);
   target?.appendChild(node);
 }
 
-function getTarget(options: PortalOptions = {}) {
+function getTarget(options: PortalOptions = {}, fallbackTarget: Element | null) {
   const target = typeof options === 'object' ? options.target : undefined;
   if (target instanceof HTMLElement) {
     return target;
   } else if (typeof target === 'string') {
     return document.querySelector(target);
   } else {
-    return document.body;
+    return fallbackTarget ?? document.body;
   }
 }

--- a/packages/svelte-ux/src/lib/actions/portal.ts
+++ b/packages/svelte-ux/src/lib/actions/portal.ts
@@ -25,7 +25,6 @@ export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
 
   return {
     update(options) {
-      console.log(options);
       moveNode(node, options, targets);
     },
     destroy() {

--- a/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
@@ -1,11 +1,101 @@
 <script lang="ts">
   import Preview from '$lib/components/Preview.svelte';
-  import Blockquote from '$docs/Blockquote.svelte';
   import Code from '$lib/components/Code.svelte';
+  import { portal, type PortalOptions } from '$lib/actions/portal.js';
+  import Button from '$lib/components/Button.svelte';
 
-  import { portal } from '$lib/actions/portal.js';
+  let optionsBasic: PortalOptions = false;
+  let optionsAnscestor: PortalOptions = false;
+  let optionsSibling: PortalOptions = false;
+  let optionsCustom: PortalOptions = false;
 </script>
 
 <h1>Usage</h1>
 
 <Code source={`import { portal } from 'svelte-ux';`} language="javascript" />
+
+<h1>Examples</h1>
+
+<h2>basic</h2>
+
+<Preview>
+  <div class="relative">
+    <Button on:click={() => (optionsBasic = true)} class="border mt-4">Move to body</Button>
+    <div use:portal={optionsBasic} class="portal-content">
+      <div>Portal content</div>
+      {#if optionsBasic}
+        <Button on:click={() => (optionsBasic = false)} class="border mt-4">
+          Move to back to parent
+        </Button>
+      {/if}
+    </div>
+  </div>
+</Preview>
+
+<h2>first/sibling <code>.PortalTarget</code></h2>
+
+<Preview>
+  <div class="relative">
+    <Button on:click={() => (optionsSibling = true)} class="border mt-4">
+      Move to first <code>.PortalTarget</code>
+    </Button>
+    <div use:portal={optionsSibling} class="portal-content">
+      <div>Portal content</div>
+      {#if optionsSibling}
+        <Button on:click={() => (optionsSibling = false)} class="border mt-4">
+          Move to back to parent
+        </Button>
+      {/if}
+    </div>
+  </div>
+  <div class="PortalTarget relative h-32 bg-surface-200 mt-4"></div>
+</Preview>
+
+<h2>anscestor <code>.PortalTarget</code></h2>
+<!-- This example has to come after the previous one, so the previous one doesn't find this .PortalTarget -->
+
+<Preview>
+  <div class="PortalTarget relative">
+    <div>
+      <Button on:click={() => (optionsAnscestor = true)} class="border mt-4">
+        Move to closest <code>.PortalTarget</code>
+      </Button>
+      <div use:portal={optionsAnscestor} class="portal-content">
+        <div>Portal content</div>
+        {#if optionsAnscestor}
+          <Button on:click={() => (optionsAnscestor = false)} class="border mt-4">
+            Move to back to parent
+          </Button>
+        {/if}
+      </div>
+    </div>
+  </div>
+</Preview>
+
+<h2>custom target</h2>
+
+<Preview>
+  <div class="relative">
+    <Button
+      on:click={() => (optionsCustom = { target: '.custom-portal-target' })}
+      class="border mt-4"
+    >
+      Move to <code>.custom-portal-target</code>
+    </Button>
+    <div use:portal={optionsCustom} class="portal-content">
+      <div>Portal content</div>
+      {#if optionsCustom}
+        <Button on:click={() => (optionsCustom = false)} class="border mt-4">
+          Move to back to parent
+        </Button>
+      {/if}
+    </div>
+  </div>
+  <div class="custom-portal-target relative h-32 bg-surface-200 mt-4"></div>
+</Preview>
+
+<style lang="postcss">
+  .portal-content {
+    @apply absolute top-1/2 left-1/2 shadow bg-surface-100 p-4 -translate-x-1/2 -translate-y-1/2 text-center;
+  }
+</style>


### PR DESCRIPTION
Adds `PortalTarget` ([as discussed](https://github.com/techniq/svelte-ux/issues/29#issuecomment-2091476032)) as a well known class that can be used to globally customize the default portal target used by the portal action.

I also:
- Added examples of the different target approaches (see screenshot below)
- Changed the portal logic to put the portal back in its original parent if it becomes disabled (rather than doing nothing)
I expect this was just an oversight so far. If a portal is initially disabled, it just stays in its original parent, so it seems to make sense to consider that its "disabled state". And if a user doesn't want the portal to move, they just shouldn't change the options.
I primarily made the change, because it meant that I needed less code for the examples, but I think that it's the intuitive behaviour.

![image](https://github.com/techniq/svelte-ux/assets/12587509/d122c121-cc2d-4f53-aa0f-e6d708e11332)
