### PR TITLE
RangeSlider: add disableTooltips option

### DIFF
--- a/.changeset/angry-months-matter.md
+++ b/.changeset/angry-months-matter.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+[RangeSlider] Add disableTooltips property

--- a/packages/svelte-ux/src/lib/components/RangeSlider.svelte
+++ b/packages/svelte-ux/src/lib/components/RangeSlider.svelte
@@ -41,6 +41,7 @@
   export let step = 1;
   export let value = [min, max];
   export let disabled = false;
+  export let disableTooltips = false;
 
   let className: string | undefined = undefined;
   export { className as class };
@@ -309,7 +310,7 @@
     )}
   />
 
-  {#if showStartValue}
+  {#if showStartValue && !disableTooltips}
     <output
       style="left: calc(var(--start) * 100%);"
       class="value absolute top-1/2 -translate-x-1/2 -translate-y-[180%] text-xs text-primary-content bg-primary rounded-full px-2 shadow"
@@ -319,7 +320,7 @@
     </output>
   {/if}
 
-  {#if showEndValue}
+  {#if showEndValue && !disableTooltips}
     <output
       style="left: calc(var(--end) * 100%);"
       class="value absolute top-1/2 -translate-x-1/2 -translate-y-[180%] text-xs text-primary-content bg-primary rounded-full px-2 shadow"

--- a/packages/svelte-ux/src/routes/docs/components/RangeSlider/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/RangeSlider/+page.svelte
@@ -48,3 +48,9 @@
 <Preview>
   <RangeSlider max={100} step={10} />
 </Preview>
+
+<h2>disableTooltips</h2>
+
+<Preview>
+  <RangeSlider disableTooltips />
+</Preview>


### PR DESCRIPTION
# What changed?

Add option to `RangeSlider` component to disable tooltips. 

```jsx
  <RangeSlider disableTooltips />
```

Update documentation to provide example:
<img width="584" alt="Screenshot 2024-05-15 at 7 21 32 PM" src="https://github.com/techniq/svelte-ux/assets/445312/b708d3e2-a16d-4546-abff-556e8877202f">

# How was it tested?

Development server was spun up on branch, changes were validated using:

```bash
pnpm i
cd packages/svelte-ux; pnpm dev
```

Unit tests were run but 6 tests failed. These tests also failed on `main`, so I'm assuming they are unrelated to this change. 