### PR TITLE
Fix create-svelte-ux on windows

### DIFF
--- a/.changeset/wet-experts-wait.md
+++ b/.changeset/wet-experts-wait.md
@@ -1,0 +1,5 @@
+---
+'create-svelte-ux': minor
+---
+
+Fix path error on windows machines

--- a/packages/create-svelte-ux/bin.js
+++ b/packages/create-svelte-ux/bin.js
@@ -188,8 +188,9 @@ function copy(
   }
 }
 
-function sourcePath(/** @type {string} */ path) {
-  return fileURLToPath(new URL(path, import.meta.url).href);
+function sourcePath(/** @type {string} */ file) {
+  let __dirname = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(__dirname, file)
 }
 
 function pCancel(cancelText = 'Operation cancelled.') {


### PR DESCRIPTION
When using "npm create svelte-ux@latest" on a windows machine it wouldn't work. Not tested on Linux thou.