### PR TITLE
Fix overflow in starter template nav slots

### DIFF
--- a/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
+++ b/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
@@ -8,7 +8,7 @@
 		classes: {
 			AppBar: 'bg-primary text-white shadow-md',
 			AppLayout: {
-				nav: 'bg-neutral-800'
+				nav: 'bg-neutral-800 py-2'
 			},
 			NavItem: {
 				root: 'text-sm text-gray-400 pl-6 py-2 hover:text-white hover:bg-gray-300/10 [&:where(.is-active)]:text-sky-400 [&:where(.is-active)]:bg-gray-500/10'
@@ -24,7 +24,6 @@
 			text="Home"
 			icon="M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z"
 			currentUrl={$page.url}
-			class="mt-2"
 		/>
 
 		<NavItem

--- a/packages/create-svelte-ux/templates/starter/src/routes/+layout.svelte
+++ b/packages/create-svelte-ux/templates/starter/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
 			},
 			AppLayout: {
 				classes: {
-					nav: 'bg-neutral-800'
+					nav: 'bg-neutral-800 py-2'
 				}
 			},
 			NavItem: {
@@ -30,7 +30,6 @@
 			text="Home"
 			icon="M10,20V14H14V20H19V12H22L12,3L2,12H5V20H10Z"
 			currentUrl={$page.url}
-			class="mt-2"
 		/>
 
 		<NavItem


### PR DESCRIPTION
Fixes an overflow resulting in a scrollbar. 

E.g., current after creating the starter template (changed the nav bg to red to increase contrast):

https://github.com/techniq/svelte-ux/assets/34311583/70df67aa-004e-4778-b0f9-081d6932fb08


With the changes, the same property class (`py-2`) is used as on the libs website, which won't result in an overflow as long as the nav items fit into the container.

---

_Related to this, having looked into the AppLayouts slots for the navigation_: would it be too pedantic to change the nav slot in the templates to remove the redundant use of `nav` tags in a follow-up PR?

E.g., current:
![Screenshot_20240522_230535](https://github.com/techniq/svelte-ux/assets/34311583/68f28383-b38b-4a4a-9301-9448bae9a4c9)


https://github.com/techniq/svelte-ux/blob/e227b188736b7c4bdfa62e27f80f646f67fbf955/packages/create-svelte-ux/templates/starter/src/routes/+layout.svelte#L27

Afaik the following could work without having to make compromises:

```diff
-<nav slot="nav" class="nav h-full">
+<div slot="nav" class="h-full">
```




