### PR TITLE
Update nav slot tags in `AppLayout`s to improve markup semantics

### DIFF
--- a/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
+++ b/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <AppLayout>
-	<nav slot="nav" class="nav h-full">
+	<svelte:fragment slot="nav">
 		<NavItem
 			path="/"
 			text="Home"
@@ -39,7 +39,7 @@
 			icon="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
 			currentUrl={$page.url}
 		/>
-	</nav>
+	</svelte:fragment>
 
 	<AppBar title="Svelte UX Starter">
 		<div slot="actions" class="flex gap-3">

--- a/packages/create-svelte-ux/templates/starter/src/routes/+layout.svelte
+++ b/packages/create-svelte-ux/templates/starter/src/routes/+layout.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <AppLayout>
-	<nav slot="nav" class="nav h-full">
+	<svelte:fragment slot="nav">
 		<NavItem
 			path="/"
 			text="Home"
@@ -38,7 +38,7 @@
 			icon="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"
 			currentUrl={$page.url}
 		/>
-	</nav>
+	</svelte:fragment>
 
 	<AppBar title="Svelte UX Starter">
 		<div slot="actions" class="flex gap-3">

--- a/packages/svelte-ux/src/routes/+layout.svelte
+++ b/packages/svelte-ux/src/routes/+layout.svelte
@@ -205,11 +205,11 @@
 <ThemeInit />
 
 <AppLayout>
-  <nav slot="nav" class="h-full">
+  <svelte:fragment slot="nav">
     <NavMenu />
     <!-- Spacer -->
     <div class="h-4" />
-  </nav>
+  </svelte:fragment>
 
   <AppBar {title}>
     <div slot="actions" class="flex gap-3">

--- a/packages/svelte-ux/src/routes/docs/components/AppLayout/+page.md
+++ b/packages/svelte-ux/src/routes/docs/components/AppLayout/+page.md
@@ -8,7 +8,7 @@
 
 ```svelte
 <AppLayout>
-	<svelte:fragment slot="nav">
+  <svelte:fragment slot="nav">
     <!-- Nav menu -->
   </svelte:fragment>
 
@@ -28,7 +28,7 @@
 
 ```svelte
 <AppLayout areas="'header header' 'aside main'">
-	<svelte:fragment slot="nav">
+  <svelte:fragment slot="nav">
     <!-- Nav menu -->
   </svelte:fragment>
 

--- a/packages/svelte-ux/src/routes/docs/components/AppLayout/+page.md
+++ b/packages/svelte-ux/src/routes/docs/components/AppLayout/+page.md
@@ -8,9 +8,9 @@
 
 ```svelte
 <AppLayout>
-  <nav slot="nav" class="h-full">
+	<svelte:fragment slot="nav">
     <!-- Nav menu -->
-  </nav>
+  </svelte:fragment>
 
   <AppBar title="Example">
     <div slot="actions">
@@ -28,9 +28,9 @@
 
 ```svelte
 <AppLayout areas="'header header' 'aside main'">
-  <nav slot="nav" class="h-full">
+	<svelte:fragment slot="nav">
     <!-- Nav menu -->
-  </nav>
+  </svelte:fragment>
 
   <AppBar title="Example">
     <div slot="actions">


### PR DESCRIPTION
I think using a `svelte:fragment` tag here could be the cleanest solution for the default, resulting in the least amount of redundancies in required class assignments and tags in the final markup.

Refs.: https://svelte.dev/docs/special-elements#svelte-fragment, https://learn.svelte.dev/tutorial/svelte-fragment

If the suggestion is appropriate, please also update the PR message if there is something that fits better.