### PR TITLE
Improve search accessibility and make minor style updates

### DIFF
--- a/.changeset/late-carrots-draw.md
+++ b/.changeset/late-carrots-draw.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": minor
+---
+
+Improve search accessibility and make minor style updates

--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -66,21 +66,21 @@
     backdrop: 'backdrop-blur-sm',
   }}
 >
-  <div class="overflow-auto max-h-[min(90dvh,600px)] w-[400px] max-w-[95vw] py-1">
-    <SelectField
-      icon={mdiMagnify}
-      placeholder="Search..."
-      inlineOptions={true}
-      {options}
-      {fieldActions}
-      on:change
-      on:change={() => (open = false)}
-      classes={{
-        field: {
-          container: 'border-none hover:shadow-none group-focus-within:shadow-none',
-        },
-        group: 'capitalize',
-      }}
-    />
-  </div>
+  <SelectField
+    icon={mdiMagnify}
+    placeholder="Search..."
+    inlineOptions={true}
+    {options}
+    {fieldActions}
+    on:change
+    on:change={() => (open = false)}
+    classes={{
+      root: 'w-[420px] max-w-[95vw] py-1',
+      field: {
+        container: 'border-none hover:shadow-none group-focus-within:shadow-none',
+      },
+      options: 'overflow-auto max-h-[min(90dvh,380px)]',
+      group: 'capitalize',
+    }}
+  />
 </Dialog>

--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -36,6 +36,9 @@
     if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       open = !open;
+    } else if (open && e.key === 'Escape') {
+      e.preventDefault();
+      open = !open;
     }
   }
 </script>

--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -62,7 +62,7 @@
 <Dialog
   bind:open
   classes={{
-    root: cls('items-start mt-20', settingsClasses.root, classes.root, $$props.class),
+    root: cls('items-start mt-8 sm:mt-24', settingsClasses.root, classes.root, $$props.class),
     backdrop: 'backdrop-blur-sm',
   }}
 >

--- a/packages/svelte-ux/src/lib/components/QuickSearch.svelte
+++ b/packages/svelte-ux/src/lib/components/QuickSearch.svelte
@@ -25,11 +25,7 @@
 
   /*
     TODO:
-     - [ ] Sticky search
-     - [ ] Improve size of Dialog (move class to Dialog without breaking overflow)
      - [ ] Load descriptions/meta from +page.ts
-     - [ ] Improve dialog positioning on small viewports (consistent top/bottom with max height)
-     - [ ] Improve look of search field
   */
 
   function onKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
The changes resolve some TODOs for the search field and improve accessibility.

The updates regard:
- Persistent/sticky search input field
- Keyboard navigation fixes
- Closing the search with esc
- Alignment in small viewports

---

I made a short screencast, hoping it will help as a quick and convenient way to present go over the changes.

https://github.com/techniq/svelte-ux/assets/34311583/4768e47d-2a4a-4cdf-9deb-241f48e53884

