### PR TITLE
Detect package manager in create script to give customized next steps

### DIFF
--- a/.changeset/rare-suits-fold.md
+++ b/.changeset/rare-suits-fold.md
@@ -1,0 +1,5 @@
+---
+'create-svelte-ux': minor
+---
+
+Detect package manager for customized "Next Steps"

--- a/packages/create-svelte-ux/bin.js
+++ b/packages/create-svelte-ux/bin.js
@@ -125,12 +125,16 @@ copy(
   ['.meta.json']
 );
 
+const userAgent = process.env.npm_config_user_agent;
+const pm = userAgent ? userAgent.split('/')[0] : 'npm';
+const runCmd = pm === 'pnpm' ? 'dev' : 'run dev';
+
 p.outro(`🎉 Everything is ready!
 
 👉 Next Steps
 0️⃣  Go to your project     :  cd ${green(projectDir)}
-1️⃣  Install dependencies   :  ${green(`npm i`)}       | ${green(`pnpm i`)}
-2️⃣  Start your application :  ${green(`npm run dev`)} | ${green(`pnpm dev`)}`);
+1️⃣  Install dependencies   :  ${green(`${pm} i`)}
+2️⃣  Start your application :  ${green(`${pm} ${runCmd}`)}`)
 
 console.log(
   gray(

--- a/packages/create-svelte-ux/bin.js
+++ b/packages/create-svelte-ux/bin.js
@@ -134,7 +134,7 @@ p.outro(`🎉 Everything is ready!
 👉 Next Steps
 0️⃣  Go to your project     :  cd ${green(projectDir)}
 1️⃣  Install dependencies   :  ${green(`${pm} i`)}
-2️⃣  Start your application :  ${green(`${pm} ${runCmd}`)}`)
+2️⃣  Start your application :  ${green(`${pm} ${runCmd}`)}`);
 
 console.log(
   gray(


### PR DESCRIPTION
Will print the next steps based on the used package manager. 
E.g. this will also include the new kid on the block _bun_:

Examples:
|||
|:-:|:-:|
|**npm**|**yarn**|
|![Screenshot_20240601_030041](https://github.com/techniq/svelte-ux/assets/34311583/8273217f-7fcd-4528-90b1-1a120ea4c18e)|![Screenshot_20240601_030422](https://github.com/techniq/svelte-ux/assets/34311583/a5b8cecd-7e7c-4971-9249-e164cf5c1fbf)|
|**pnpm**|**bun**|
|![Screenshot_20240601_031225](https://github.com/techniq/svelte-ux/assets/34311583/3edd0ef1-46e9-4d3a-a9cf-a09ab309d058)|![Screenshot_20240601_030509](https://github.com/techniq/svelte-ux/assets/34311583/42cd184f-be50-458a-bf96-cd735e2f112e)|

If this change can make it, is a changeset needed?
