### PR TITLE
Allow to set up templates with Svelte 5

### DIFF
--- a/.changeset/good-panthers-carry.md
+++ b/.changeset/good-panthers-carry.md
@@ -1,0 +1,5 @@
+---
+'create-svelte-ux': minor
+---
+
+Allow to set up templates with Svelte 5

--- a/packages/create-svelte-ux/bin.js
+++ b/packages/create-svelte-ux/bin.js
@@ -114,7 +114,7 @@ const svelteNext = await p.confirm({
 if (p.isCancel(svelteNext)) {
   process.exit(1);
 }
-const svelteVersion = svelteNext ? '^5.0.0-next.148' : '^4.2.17';
+const svelteVersion = svelteNext ? 'next' : 'latest';
 
 const templateDir = path.join(templatesDir, template);
 const templateMeta = options.find((option) => option.value === template);

--- a/packages/create-svelte-ux/bin.js
+++ b/packages/create-svelte-ux/bin.js
@@ -107,6 +107,15 @@ const template = options_cli.template
 if (p.isCancel(template)) {
   process.exit(1);
 }
+const svelteNext = await p.confirm({
+  message: 'Would you like to use Svelte 5 (unstable)?',
+  initialValue: false,
+});
+if (p.isCancel(svelteNext)) {
+  process.exit(1);
+}
+const svelteVersion = svelteNext ? '^5.0.0-next.148' : '^4.2.17';
+
 const templateDir = path.join(templatesDir, template);
 const templateMeta = options.find((option) => option.value === template);
 if (!templateMeta) {
@@ -120,6 +129,7 @@ copy(
   {
     PROJECT_NAME: projectName,
     SVELTE_UX_VERSION: version,
+    SVELTE_VERSION: svelteVersion,
   },
   { '.meta..gitignore': '.gitignore' },
   ['.meta.json']

--- a/packages/create-svelte-ux/templates/minimal/package.json
+++ b/packages/create-svelte-ux/templates/minimal/package.json
@@ -31,7 +31,7 @@
     "postcss-load-config": "^5.1.0",
     "prettier": "^3.2.5",
     "prettier-plugin-svelte": "^3.2.3",
-    "svelte": "^4.2.17",
+    "svelte": "SVELTE_VERSION",
     "svelte-check": "^3.8.0",
     "svelte-ux": "latest",
     "tailwindcss": "^3.4.3",

--- a/packages/create-svelte-ux/templates/starter/package.json
+++ b/packages/create-svelte-ux/templates/starter/package.json
@@ -31,7 +31,7 @@
     "postcss-load-config": "^5.1.0",
     "prettier": "^3.2.5",
     "prettier-plugin-svelte": "^3.2.3",
-    "svelte": "^4.2.17",
+    "svelte": "SVELTE_VERSION",
     "svelte-check": "^3.8.0",
     "svelte-ux": "latest",
     "tailwindcss": "^3.4.3",


### PR DESCRIPTION
Adds a step to the create-setup to choose whether to use Svelte 5.

![Screenshot_20240601_182557](https://github.com/techniq/svelte-ux/assets/34311583/ddc9fe2a-9e8e-4854-8d9b-b4d1badfa5ba)

Best after resolving #377, as the updates would likely create a conflict.