### PR TITLE
Fix .contains() does not mean it's a child

### DIFF
--- a/.changeset/ninety-seals-marry.md
+++ b/.changeset/ninety-seals-marry.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Fix destroyable portal logic

--- a/packages/svelte-ux/src/lib/actions/portal.ts
+++ b/packages/svelte-ux/src/lib/actions/portal.ts
@@ -21,37 +21,41 @@ export const portal: Action<HTMLElement, PortalOptions> = (node, options) => {
     fallbackTarget: node.closest('.PortalTarget') ?? document.querySelector('.PortalTarget'),
     originalParent: node.parentElement,
   };
-  moveNode(node, options, targets);
+  let currentTarget = moveNode(node, options, targets);
 
   return {
     update(options) {
-      moveNode(node, options, targets);
+      currentTarget = moveNode(node, options, targets);
     },
     destroy() {
-      const target = getTarget(options, targets.fallbackTarget);
       // If target still contains node that was moved, remove it.  Not sure if required
-      if (target?.contains(node)) {
-        target.removeChild(node);
+      if (currentTarget && node.parentElement === currentTarget) {
+        currentTarget.removeChild(node);
       }
     },
   };
 };
 
-function moveNode(node: HTMLElement, options: PortalOptions = {}, targets: PortalTargets) {
+function moveNode(
+  node: HTMLElement,
+  options: PortalOptions = {},
+  targets: PortalTargets
+): Element | null {
   const enabled = typeof options === 'boolean' ? options : options.enabled;
   if (enabled === false) {
     // Put it back where it came from
     if (targets.originalParent !== node.parentElement) {
       targets.originalParent?.appendChild(node);
     }
-    return;
+    return targets.originalParent;
   }
 
   const target = getTarget(options, targets.fallbackTarget);
   target?.appendChild(node);
+  return target;
 }
 
-function getTarget(options: PortalOptions = {}, fallbackTarget: Element | null) {
+function getTarget(options: PortalOptions = {}, fallbackTarget: Element | null): Element | null {
   const target = typeof options === 'object' ? options.target : undefined;
   if (target instanceof HTMLElement) {
     return target;

--- a/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
@@ -27,7 +27,7 @@
       <div>Portal content</div>
       {#if optionsBasic}
         <Button on:click={() => (optionsBasic = false)} class="border mt-4">
-          Move to back to parent
+          Move back to parent
         </Button>
       {/if}
     </div>
@@ -45,7 +45,7 @@
       <div>Portal content</div>
       {#if optionsSibling}
         <Button on:click={() => (optionsSibling = false)} class="border mt-4">
-          Move to back to parent
+          Move back to parent
         </Button>
       {/if}
     </div>
@@ -66,7 +66,7 @@
         <div>Portal content</div>
         {#if optionsAnscestor}
           <Button on:click={() => (optionsAnscestor = false)} class="border mt-4">
-            Move to back to parent
+            Move back to parent
           </Button>
         {/if}
       </div>
@@ -88,7 +88,7 @@
       <div>Portal content</div>
       {#if optionsCustom}
         <Button on:click={() => (optionsCustom = false)} class="border mt-4">
-          Move to back to parent
+          Move back to parent
         </Button>
       {/if}
     </div>
@@ -117,7 +117,7 @@
           <div>Portal content</div>
           {#if optionsBasic}
             <Button on:click={() => (optionsBasic = false)} class="border mt-4">
-              Move to back to parent
+              Move back to parent
             </Button>
           {/if}
         </div>

--- a/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
@@ -106,13 +106,7 @@
           on:click={() => (optionsDestroyable = { target: '.destroyable-example-target' })}
           class="border mt-4">Move to target</Button
         >
-        <Button on:click={() => (destroy = !destroy)} class="border mt-4">
-          {#if destroy}
-            Recreate
-          {:else}
-            Destroy
-          {/if}
-        </Button>
+        <Button on:click={() => (destroy = true)} class="border mt-4">Destroy</Button>
         <div use:portal={optionsDestroyable} class="portal-content">
           <div>Portal content</div>
           {#if optionsBasic}
@@ -124,6 +118,8 @@
       </div>
       <div class="destroyable-example-target relative h-32 bg-surface-200 mt-4"></div>
     </div>
+  {:else}
+    <Button on:click={() => (destroy = false)} class="border mt-4">Recreate</Button>
   {/if}
 </Preview>
 

--- a/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/actions/portal/+page.svelte
@@ -8,6 +8,8 @@
   let optionsAnscestor: PortalOptions = false;
   let optionsSibling: PortalOptions = false;
   let optionsCustom: PortalOptions = false;
+  let optionsDestroyable: PortalOptions = { target: undefined, enabled: false };
+  let destroy = false;
 </script>
 
 <h1>Usage</h1>
@@ -92,6 +94,37 @@
     </div>
   </div>
   <div class="custom-portal-target relative h-32 bg-surface-200 mt-4"></div>
+</Preview>
+
+<h2>Destroyable</h2>
+
+<Preview>
+  {#if !destroy}
+    <div class="PortalTarget relative">
+      <div class="relative">
+        <Button
+          on:click={() => (optionsDestroyable = { target: '.destroyable-example-target' })}
+          class="border mt-4">Move to target</Button
+        >
+        <Button on:click={() => (destroy = !destroy)} class="border mt-4">
+          {#if destroy}
+            Recreate
+          {:else}
+            Destroy
+          {/if}
+        </Button>
+        <div use:portal={optionsDestroyable} class="portal-content">
+          <div>Portal content</div>
+          {#if optionsBasic}
+            <Button on:click={() => (optionsBasic = false)} class="border mt-4">
+              Move to back to parent
+            </Button>
+          {/if}
+        </div>
+      </div>
+      <div class="destroyable-example-target relative h-32 bg-surface-200 mt-4"></div>
+    </div>
+  {/if}
 </Preview>
 
 <style lang="postcss">


### PR DESCRIPTION
Three things were wrong here:
- The logic here wasn't quite right. `elem1.contains(elem2)` checks all descendants, so it doesn't imply that elem2 is a child of elem1
- We shouldn't recalculate the target when the element is getting destroyed, because we won't necessarily get the current target if there have been DOM changes
- `onDestroy` was using the original `options`, which would be out of date if they had ever been changed (i.e. via `update()`)

Due to a combination of these problems, when I navigate away from a route in my application I'm currently getting:
```
Uncaught (in promise) DOMException: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
    at destroy (http://localhost:5173/node_modules/.vite/deps/svelte-ux.js?v=ed6d092c:3364:16)
```

There are just so many little details that are wrong that it turns out there are a few ways to reproduce the bug, but what's crucial in my example is that:
1) The portal is initialized with `{target: undefined}` so that in `onDestroy` it queries for the nearest target.
2) There's a portal target (e.g. `.PortalTarget`) within the same `{#if}` as the portal content. Otherwise, `.contains()` will return false. The reason is that everything within the `{#if}` gets pulled out of the DOM, so root elements in the `{#if}` don't have a `parentElement`, but the elements within that detached subtree are still conntected to each other.
3) The portal content is not using that target i.e. it's not a direct child of it. It can simply be in its original parent (with `enabled: false`) or be in a different target that's also within the same `{#if}`. So, in the example you can trigger the error whether or not you've clicked "Move to target".