### PR TITLE
Fix scrolling away when opening menu

### DIFF
--- a/.changeset/swift-paws-dance.md
+++ b/.changeset/swift-paws-dance.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Fix scrolling away when opening menu

--- a/packages/svelte-ux/src/lib/actions/focus.ts
+++ b/packages/svelte-ux/src/lib/actions/focus.ts
@@ -1,5 +1,5 @@
-import { tick } from 'svelte';
 import type { ActionReturn } from 'svelte/action';
+import { delay } from '$lib/utils/promise.js';
 
 export function focusMove(
   node: HTMLElement,
@@ -14,7 +14,7 @@ export function focusMove(
     // Set `tabIndex` to `-1` which makes any element (ex. div) focusable programmaitcally (and mouse), but not via keyboard navigation - https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
     node.tabIndex = -1;
     // Appear to need to wait for tabIndex to update before applying focus
-    tick().then(() => {
+    delay(0).then(() => {
       node.focus();
     });
 


### PR DESCRIPTION
I put a my reproduction from the recordings followed by the bug fix in [this branch](https://github.com/myieye/svelte-ux/tree/bug/focusMove-scrolls-to-parent-reproduction). (i.e. revert the fix to see the bug)

Before:
![broken-scrolling](https://github.com/techniq/svelte-ux/assets/12587509/c809d522-193f-43fc-b7d9-3a4a7c3125cd)

After:
![fixed-scrolling](https://github.com/techniq/svelte-ux/assets/12587509/4de1eeff-dd5d-4216-9883-50d7f6ddbf03)

I'm not sure how to create an example for this, because I can only reproduce it when <body>/<html> are larger than the viewport. Somehow focusing on the element too early makes the browser scroll to the wrong place.