### PR TITLE
Fix error from keying on stringified objects

### DIFF
--- a/.changeset/little-penguins-sort.md
+++ b/.changeset/little-penguins-sort.md
@@ -1,0 +1,5 @@
+---
+"svelte-ux": patch
+---
+
+Fix error from keying on stringified objects

--- a/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
+++ b/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
@@ -75,7 +75,7 @@
     onKeyPress(e);
   }}
 >
-  {#each filteredOptions ?? [] as option, index (`${option.group}-${optionValue(option)}`)}
+  {#each filteredOptions ?? [] as option, index (`${option.group}-${optionValue(option)}-${optionText(option)}`)}
     {@const previousOption = filteredOptions[index - 1]}
     {#if option.group && option.group !== previousOption?.group}
       <div

--- a/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
@@ -117,6 +117,19 @@
   />
 </Preview>
 
+<h2>Object value options</h2>
+
+<Preview>
+  <SelectField
+    options={[
+      { label: 'Empty', value: null },
+      { label: 'Foo', value: { id: 1 } },
+      { label: 'Bar', value: { id: 2 } },
+      { label: 'Baz', value: { id: 3 } },
+    ]}
+  />
+</Preview>
+
 <h2>Many options</h2>
 
 <Preview>


### PR DESCRIPTION
As the added example demonstrates, if you use objects in a SelectField, it causes an error, because the keyed each has duplicate keys (i.e. `[Object object]`). Perhaps I should just remove the `-${optionValue(option)}` part? In theory that would be a _slightly_ more breaking change, but it would probably be fine.

There's an inconsistency in the select-fields in that the MultiSelect value field is of type string[] | number[] 🤷 while SelectField value is of type `any`. Is that intentional?