### PR TITLE
Pass object of classes through Select-like fields to Field instances

### DIFF
--- a/.changeset/friendly-squids-attack1.md
+++ b/.changeset/friendly-squids-attack1.md
@@ -2,4 +2,4 @@
 'svelte-ux': patch
 ---
 
-adds a function `normalizeClasses` to normalize classes when they can be a string or an object, essentially converting strings to objects (e.g. `'p-2'` ➞ `{ root: 'p-2' }`)
+adds a function `normalizeClasses` to normalize classes when they can be a string or an object, essentially converting strings to objects

--- a/.changeset/friendly-squids-attack1.md
+++ b/.changeset/friendly-squids-attack1.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+adds a function `normalizeClasses` to normalize classes when they can be a string or an object, essentially converting strings to objects (e.g. `'p-2'` ➞ `{ root: 'p-2' }`)

--- a/.changeset/friendly-squids-attack2.md
+++ b/.changeset/friendly-squids-attack2.md
@@ -2,4 +2,4 @@
 'svelte-ux': patch
 ---
 
-adds a function `clsMerge` for merging groups of classes without needing to do more complex property-by-property merging (e.g. `{ root: cls(settingsClasses.root, 'grid', classes.root), field: cls(settingsClasses.field, 'flex', classes.field) }` ➞ `clsMerge(settingsClasses, { root: 'grid', field: 'flex' }, classes)`)
+adds a function `clsMerge` for merging groups of classes without needing to do more complex property-by-property merging

--- a/.changeset/friendly-squids-attack2.md
+++ b/.changeset/friendly-squids-attack2.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+adds a function `clsMerge` for merging groups of classes without needing to do more complex property-by-property merging (e.g. `{ root: cls(settingsClasses.root, 'grid', classes.root), field: cls(settingsClasses.field, 'flex', classes.field) }` ➞ `clsMerge(settingsClasses, { root: 'grid', field: 'flex' }, classes)`)

--- a/.changeset/friendly-squids-attack3.md
+++ b/.changeset/friendly-squids-attack3.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+passes the `classes` objects down to the `TextField` component from the `Select` and `MultiSelect` components

--- a/.changeset/friendly-squids-attack4.md
+++ b/.changeset/friendly-squids-attack4.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fixes a TypeError caused by a faulty ReturnType from `entries()` and removes a related `@ts-expect-error`

--- a/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
@@ -11,7 +11,7 @@
   import MultiSelectOption from './MultiSelectOption.svelte';
   import TextField from './TextField.svelte';
 
-  import { cls } from '../utils/styles.js';
+  import { cls, clsMerge, normalizeClasses } from '../utils/styles.js';
   import { Logger } from '../utils/logger.js';
   import ProgressCircle from './ProgressCircle.svelte';
 
@@ -47,7 +47,7 @@
   export let classes: {
     root?: string;
     multiSelectMenu?: MultiSelectMenuProps['classes'];
-    field?: string;
+    field?: string | ComponentProps<TextField>['classes'];
     actions?: string;
   } = {};
 
@@ -154,7 +154,11 @@
     bind:inputEl
     on:focus={onFocus}
     on:change={onSearchChange}
-    class={cls('h-full', settingsClasses.field, classes.field)}
+    classes={clsMerge(
+      normalizeClasses(settingsClasses.field),
+      { root: 'h-full' },
+      normalizeClasses(classes.field),
+    )}
     {...restProps}
   >
     <slot slot="prepend" name="prepend" />

--- a/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
@@ -157,7 +157,7 @@
     classes={clsMerge(
       normalizeClasses(settingsClasses.field),
       { root: 'h-full' },
-      normalizeClasses(classes.field),
+      normalizeClasses(classes.field)
     )}
     {...restProps}
   >

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -435,7 +435,7 @@
           ? 'border-none shadow-none hover:shadow-none group-focus-within:shadow-none'
           : undefined,
       },
-      normalizeClasses(classes.field),
+      normalizeClasses(classes.field)
     )}
     role="combobox"
     aria-expanded={open ? 'true' : 'false'}

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -6,7 +6,7 @@
 
   import { Logger } from '../utils/logger.js';
   import { autoFocus, selectOnFocus } from '../actions/input.js';
-  import { cls } from '../utils/styles.js';
+  import { cls, clsMerge, normalizeClasses } from '../utils/styles.js';
 
   import Button from './Button.svelte';
   import ProgressCircle from './ProgressCircle.svelte';
@@ -427,12 +427,16 @@
     on:keydown={onKeyDown}
     on:keypress={onKeyPress}
     actions={fieldActions}
-    classes={{
-      container: inlineOptions
-        ? 'border-none shadow-none hover:shadow-none group-focus-within:shadow-none'
-        : undefined,
-    }}
-    class={cls('h-full', settingsClasses.field, fieldClasses)}
+    classes={clsMerge(
+      normalizeClasses(settingsClasses.field),
+      {
+        root: 'h-full',
+        container: inlineOptions
+          ? 'border-none shadow-none hover:shadow-none group-focus-within:shadow-none'
+          : undefined,
+      },
+      normalizeClasses(classes.field),
+    )}
     role="combobox"
     aria-expanded={open ? 'true' : 'false'}
     aria-autocomplete={!inlineOptions ? 'list' : undefined}

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -41,10 +41,10 @@ export function keys<T extends object>(o: T) {
 export type ObjectKey = string | number | symbol;
 
 // Get entries (array of [key, value] arrays) of object (strongly-typed)
-export function entries<K extends ObjectKey, V>(o: Record<K, V>): [K, V][];
+export function entries<K extends ObjectKey, V>(o: Record<K, V>): [`${Extract<K, string | number>}`, V][];
 export function entries<K, V>(o: Map<K, V>): [K, V][];
 // @ts-expect-error
-export function entries<K extends ObjectKey | unknown, V>(o: Record<K, V> | Map<K, V>): [K, V][] {
+export function entries<K extends ObjectKey | unknown, V>(o: Record<K, V> | Map<K, V>) {
   if (o instanceof Map) return Array.from(o.entries()) as unknown as [K, V][];
   return Object.entries(o) as unknown as [K, V][]; // TODO: Improve based on key/value pair - https://stackoverflow.com/questions/60141960/typescript-key-value-relation-preserving-object-entries-type
 }

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -41,7 +41,9 @@ export function keys<T extends object>(o: T) {
 export type ObjectKey = string | number | symbol;
 
 // Get entries (array of [key, value] arrays) of object (strongly-typed)
-export function entries<K extends ObjectKey, V>(o: Record<K, V>): [`${Extract<K, string | number>}`, V][];
+export function entries<K extends ObjectKey, V>(
+  o: Record<K, V>
+): [`${Extract<K, string | number>}`, V][];
 export function entries<K, V>(o: Map<K, V>): [K, V][];
 // @ts-expect-error
 export function entries<K extends ObjectKey | unknown, V>(o: Record<K, V> | Map<K, V>) {

--- a/packages/svelte-ux/src/lib/utils/styles.ts
+++ b/packages/svelte-ux/src/lib/utils/styles.ts
@@ -42,19 +42,15 @@ const twMerge = extendTailwindMerge({
 
 type ClassFalsyValues = undefined | null | false;
 type AnyClassValue = ClassValue | ClassFalsyValues;
-type AnyClassCollection =
-  | Record<string | number | symbol, AnyClassValue>
-  | ClassFalsyValues;
+type AnyClassCollection = Record<string | number | symbol, AnyClassValue> | ClassFalsyValues;
 
 export const cls = (...inputs: AnyClassValue[]) => twMerge(clsx(...inputs));
 
 export const clsMerge = <T extends AnyClassCollection>(
   ...inputs: T[]
 ): Exclude<T, false | undefined> =>
-  mergeWith({}, ...inputs.filter(Boolean), (a: string, b: string) =>
-    twMerge(a, b)
-  );
+  mergeWith({}, ...inputs.filter(Boolean), (a: string, b: string) => twMerge(a, b));
 
 export const normalizeClasses = <T extends object>(classes: string | ClassFalsyValues | T): T => {
-  return classes && typeof classes === 'object' ? classes : { root: classes } as T;
-}
+  return classes && typeof classes === 'object' ? classes : ({ root: classes } as T);
+};


### PR DESCRIPTION
This PR does a few things
- adds a function `normalizeClasses` to normalize classes when they can be a string or an object, essentially converting strings to objects (e.g. `'p-2'` ➞ `{ root: 'p-2' }`)

  <table>
  <thead>
  <tr>
  <th>Before</th>
  </tr>
  </thead>
  <tbody>
  <tr></tr>
  <tr>
  <td>
                  
  ```svelte
  <Component classes={typeof className === 'string' ? { root: className } : className} />
  ```
  
  </td>
  </tr>
  </tbody>
  <thead>
  <tr>
  <th>After</th>
  </tr>
  </thead>
  <tbody>
  <tr></tr>
  <tr>
  <td>
                  
  ```svelte
  <Component classes={normalizeClasses(className)} />
  ```
                  
  </td>
  </tr>
  </tbody>
  </table>

- adds a function `clsMerge` for merging groups of classes without needing to do more complex property-by-property merging

  <table>
  <thead>
  <tr>
  <th>Before</th>
  </tr>
  </thead>
  <tbody>
  <tr></tr>
  <tr>
  <td>
                  
  ```svelte
  <Component classes={{
    root: cls(settingsClasses.root, 'grid', classes.root),
    field: cls(settingsClasses.field, 'flex', classes.field)
  }} />
  ```
  
  </td>
  </tr>
  </tbody>
  <thead>
  <tr>
  <th>After</th>
  </tr>
  </thead>
  <tbody>
  <tr></tr>
  <tr>
  <td>
                  
  ```svelte
  <Component classes={clsMerge(settingsClasses, { root: 'grid', field: 'flex' }, classes)} />
  ```
                  
  </td>
  </tr>
  </tbody>
  </table>

- passes the `classes` objects down to the `TextField` component from the `Select` and `MultiSelect` components
- fixes a TypeError caused by a faulty ReturnType from `entries()` and removes a related `@ts-expect-error`