### PR TITLE
Patch incorrect order of classnames (regression from #419)

### DIFF
--- a/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelectField.svelte
@@ -155,8 +155,8 @@
     on:focus={onFocus}
     on:change={onSearchChange}
     classes={clsMerge(
-      normalizeClasses(settingsClasses.field),
       { root: 'h-full' },
+      normalizeClasses(settingsClasses.field),
       normalizeClasses(classes.field)
     )}
     {...restProps}

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -428,13 +428,13 @@
     on:keypress={onKeyPress}
     actions={fieldActions}
     classes={clsMerge(
-      normalizeClasses(settingsClasses.field),
       {
         root: 'h-full',
         container: inlineOptions
           ? 'border-none shadow-none hover:shadow-none group-focus-within:shadow-none'
           : undefined,
       },
+      normalizeClasses(settingsClasses.field),
       normalizeClasses(classes.field)
     )}
     role="combobox"


### PR DESCRIPTION
This resolves a regression re incorrect classname order, caught in this comment:
https://github.com/techniq/svelte-ux/pull/419#issuecomment-2204019023