### PR TITLE
[SelectField] Fix options with object value due to non-unique {#each} keys

### DIFF
--- a/.changeset/tough-actors-switch.md
+++ b/.changeset/tough-actors-switch.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+[SelectField] Fix options with object value due to non-unique {#each} keys

--- a/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
+++ b/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
@@ -68,7 +68,7 @@
     onKeyPress(e);
   }}
 >
-  {#each filteredOptions ?? [] as option, index (`${option.group}-${option.value}`)}
+  {#each filteredOptions ?? [] as option, index (JSON.stringify(option))}
     {@const previousOption = filteredOptions[index - 1]}
     {#if option.group && option.group !== previousOption?.group}
       <div

--- a/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
@@ -124,6 +124,19 @@
   />
 </Preview>
 
+<h2>Object value options</h2>
+
+<Preview>
+  <SelectField
+    options={[
+      { label: 'Empty', value: null },
+      { label: 'Foo', value: { id: 1 } },
+      { label: 'Bar', value: { id: 2 } },
+      { label: 'Baz', value: { id: 3 } },
+    ]}
+  />
+</Preview>
+
 <h2>Options with icons</h2>
 
 <Preview>


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
