### PR TITLE
Add `MultiSelect` fallback text when `maintainOrder` no filtered items

### DIFF
--- a/.changeset/large-yaks-shave.md
+++ b/.changeset/large-yaks-shave.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Add fallback text in `MultiSelect` when `maintainOrder` is active and no items match the search term

--- a/packages/svelte-ux/src/lib/components/MultiSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelect.svelte
@@ -205,6 +205,12 @@
           </MultiSelectOption>
         </slot>
       </div>
+    {:else}
+      {#if maintainOrder && !filteredOptions.length}
+        <div class="text-surface-content/50 text-xs py-2 px-4 mb-1">
+          There are no matching items.
+        </div>
+      {/if}
     {/each}
   </InfiniteScroll>
 

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
@@ -42,7 +42,7 @@
   <MultiSelect {options} {value} maintainOrder on:change={(e) => (value = e.detail.value)} />
 </Preview>
 
-<h2>Immediately apply changes (no actions)</h2>
+<h2>Immediately apply changes (no actions) w/ maintainOrder</h2>
 
 <Preview>
   {value.length} selected
@@ -53,6 +53,23 @@
     mode="immediate"
     on:change={(e) => (value = e.detail.value)}
   />
+</Preview>
+
+<h2>Immediately apply changes (with custom action) w/ maintainOrder</h2>
+
+<Preview>
+  {value.length} selected
+  <MultiSelect
+    {options}
+    {value}
+    maintainOrder
+    mode="immediate"
+    on:change={(e) => (value = e.detail.value)}
+  >
+    <div slot="actions">
+      <Button color="primary" icon={mdiPlus}>Add item</Button>
+    </div>
+  </MultiSelect>
 </Preview>
 
 <h2>max selected</h2>

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
@@ -40,6 +40,12 @@
   <MultiSelectField {options} {value} on:change={(e) => (value = e.detail.value)} disabled />
 </Preview>
 
+<h2>maintainOrder</h2>
+
+<Preview>
+  <MultiSelectField {options} {value} on:change={(e) => (value = e.detail.value)} maintainOrder />
+</Preview>
+
 <h2>max selected</h2>
 
 <Preview>
@@ -79,7 +85,7 @@
   />
 </Preview>
 
-<h2>Immediately apply changes (no actions)</h2>
+<h2>Immediately apply changes (no actions) w/ maintainOrder</h2>
 
 <Preview>
   <MultiSelectField
@@ -91,7 +97,7 @@
   />
 </Preview>
 
-<h2>Immediately apply changes (with custom action)</h2>
+<h2>Immediately apply changes (with custom action) w/ maintainOrder</h2>
 
 <Preview>
   <MultiSelectField

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
@@ -63,6 +63,51 @@
   </span>
 </Preview>
 
+<h2>maintainOrder</h2>
+
+<Preview>
+  <span>
+    <ToggleButton let:on={open} let:toggleOff transition={false}>
+      {value.length} selected
+      <MultiSelectMenu
+        {options}
+        {value}
+        on:change={(e) => {
+          // @ts-expect-error
+          value = e.detail.value;
+        }}
+        {open}
+        on:close={toggleOff}
+        maintainOrder
+        placeholder="Pick a number"
+      />
+    </ToggleButton>
+  </span>
+</Preview>
+
+<h2>maintainOrder w/ inlineSearch</h2>
+
+<Preview>
+  <span>
+    <ToggleButton let:on={open} let:toggleOff transition={false}>
+      {value.length} selected
+      <MultiSelectMenu
+        {options}
+        {value}
+        on:change={(e) => {
+          // @ts-expect-error
+          value = e.detail.value;
+        }}
+        {open}
+        on:close={toggleOff}
+        inlineSearch
+        maintainOrder
+        placeholder="Pick a number"
+      />
+    </ToggleButton>
+  </span>
+</Preview>
+
 <h2>many options</h2>
 
 <Preview>
@@ -129,7 +174,7 @@
   </span>
 </Preview>
 
-<h2>Immediately apply changes (no actions)</h2>
+<h2>Immediately apply changes (no actions) w/ maintainOrder</h2>
 <Preview>
   <span>
     <ToggleButton let:on={open} let:toggleOff transition={false}>
@@ -150,7 +195,7 @@
   </span>
 </Preview>
 
-<h2>Immediately apply changes (with custom action)</h2>
+<h2>Immediately apply changes (with custom action) w/ maintainOrder</h2>
 <Preview>
   <span>
     <ToggleButton let:on={open} let:toggleOff transition={false}>


### PR DESCRIPTION
Work performed outlined [below](https://github.com/techniq/svelte-ux/pull/431#discussion_r1671385844).