### PR TITLE
Fix overflow in `Code` components

### DIFF
--- a/packages/svelte-ux/src/lib/components/Code.svelte
+++ b/packages/svelte-ux/src/lib/components/Code.svelte
@@ -18,7 +18,7 @@
   } = {};
 </script>
 
-<div class={cls('Code', 'rounded', classes.root, $$props.class)}>
+<div class={cls('Code', 'rounded', 'overflow-auto', classes.root, $$props.class)}>
   {#if source}
     <div class="relative">
       <pre


### PR DESCRIPTION
Fixes the layout being corrupted due to overflow of `Code` components. E.g. visible when checking the <kbd>Svelte Add</kbd> | <kbd>Manual Install</kbd> tabs in the Getting started section on mobile.

<table>
<tr>
<th>Current</th>
<th>Updated</th>
</tr>

<tr>
<td>

https://github.com/user-attachments/assets/6d5f45ec-805d-403c-8354-955dd503a53a
</td>

<td>

<img width=300 src="https://github.com/user-attachments/assets/e525fef3-5383-4252-b6fd-bb1dc389d731" />
</td>
</tr>
</table>