### PR TITLE
Avoid uninitialized variable error in Duration component with Svelte 5

### DIFF
--- a/.changeset/chilly-donuts-brush.md
+++ b/.changeset/chilly-donuts-brush.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Avoid uninitialized variable error in Duration component with Svelte 5

--- a/packages/svelte-ux/src/lib/components/Duration.svelte
+++ b/packages/svelte-ux/src/lib/components/Duration.svelte
@@ -20,8 +20,9 @@
 
   const settingsClasses = getComponentClasses('Duration');
 
-  function getDelay() {
-    const newDuration = getDuration(start, end ?? $timer, duration);
+  function getDelay(useTimer = true) {
+    const endTime = end ?? (useTimer ? $timer : null);
+    const newDuration = getDuration(start, endTime, duration);
 
     const unitsMoreThanSeconds = [
       newDuration?.years,
@@ -43,7 +44,8 @@
   }
 
   const timer = timerStore({
-    delay: getDelay(),
+    // Pass false to avoid referencing `timer` before it exists
+    delay: getDelay(false),
     disabled: end != null,
     onTick: () => {
       // Update delay based on display duration


### PR DESCRIPTION
related to #144 