### PR TITLE
chore: Update deployment scripts

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -1,0 +1,33 @@
+name: Build Preview Deployment
+
+# cancel in-progress runs on new commits to same PR (github.event.number)
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+    cancel-in-progress: true
+
+on:
+    pull_request:
+        types: [opened, synchronize]
+
+jobs:
+    build-preview:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18.x
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build site
+              run: pnpm build
+
+            - name: Upload build artifact
+              uses: actions/upload-artifact@v4
+              with:
+                  name: preview-build
+                  path: packages/svelte-ux/.svelte-kit/cloudflare

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,37 @@
+name: Upload Preview Deployment
+
+on:
+    workflow_run:
+        workflows: [Build Preview Deployment]
+        types:
+            - completed
+
+permissions:
+    actions: read
+    deployments: write
+    contents: read
+    pull-requests: write
+
+jobs:
+    deploy-preview:
+        runs-on: ubuntu-latest
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        steps:
+            - name: Download build artifact
+              uses: actions/download-artifact@v4
+              id: preview-build-artifact
+              with:
+                  name: preview-build
+                  path: build
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  run-id: ${{ github.event.workflow_run.id }}
+
+            - name: Deploy to Cloudflare Pages
+              uses: AdrianGonz97/refined-cf-pages-action@v1
+              with:
+                  apiToken: ${{ secrets.CF_API_TOKEN }}
+                  accountId: ${{ secrets.CF_ACCOUNT_ID }}
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  projectName: svelte-ux
+                  deploymentName: Preview
+                  directory: ${{ steps.preview-build-artifact.outputs.download-path }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,7 +34,7 @@ jobs:
                   apiToken: ${{ secrets.CF_API_TOKEN }}
                   accountId: ${{ secrets.CF_ACCOUNT_ID }}
                   githubToken: ${{ secrets.GITHUB_TOKEN }}
-                  projectName: layerchart
+                  projectName: svelte-ux
                   directory: ./.svelte-kit/cloudflare
                   workingDirectory: packages/svelte-ux
                   deploymentName: Production

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,40 @@
+name: Production Deployment
+on:
+    push:
+        branches:
+            - main
+        paths:
+            - packages/create-svelte-ux/**
+            - packages/svelte/**
+
+jobs:
+    deploy-production:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            deployments: write
+        name: Deploy Production Site to Cloudflare Pages
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pnpm/action-setup@v4
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 18.x
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install
+
+            - name: Build site
+              run: pnpm build
+
+            - name: Deploy to Cloudflare Pages
+              uses: AdrianGonz97/refined-cf-pages-action@v1
+              with:
+                  apiToken: ${{ secrets.CF_API_TOKEN }}
+                  accountId: ${{ secrets.CF_ACCOUNT_ID }}
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  projectName: layerchart
+                  directory: ./.svelte-kit/cloudflare
+                  workingDirectory: packages/svelte-ux
+                  deploymentName: Production


### PR DESCRIPTION
Closes: #278 

Saw you were still using node 18.x, and left it as such, but could update if needed.

TODO:

- [x] Disable Cloudflare's GitHub integration on the repo
- [x] Add variable secrets to this repo (`CF_ACCOUNT_ID` & `CF_API_TOKEN`)
- [x] Confirm that the project name is `svelte-ux` on Cloudflare