### PR TITLE
Expose `close` and `attemptClose` methods as slot props from `Dialog`

### DIFF
--- a/.changeset/fast-actors-tease-1.md
+++ b/.changeset/fast-actors-tease-1.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Refactor `close` method in `Dialog` and `Drawer` and expose as a slot prop across all props

--- a/.changeset/fast-actors-tease-2.md
+++ b/.changeset/fast-actors-tease-2.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Remove `close-attempt` on `Dialog` and `Drawer`

--- a/.changeset/fast-actors-tease.md
+++ b/.changeset/fast-actors-tease.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Expose `close` and `attemptClose` methods as slot props from `Dialog`

--- a/.changeset/fast-actors-tease.md
+++ b/.changeset/fast-actors-tease.md
@@ -1,5 +1,0 @@
----
-'svelte-ux': patch
----
-
-Expose `close` and `attemptClose` methods as slot props from `Dialog`

--- a/packages/svelte-ux/src/lib/components/Dialog.svelte
+++ b/packages/svelte-ux/src/lib/components/Dialog.svelte
@@ -37,15 +37,19 @@
   let actionsEl: HTMLDivElement;
 
   function attemptClose() {
-    if (!persistent) {
-      open = false;
+    if (open) {
+      if (!persistent) {
+        open = false;
+      }
+      dispatch('close-attempt', { open });
     }
-    dispatch('close-attempt', { open });
   }
 
   function close() {
-    open = false;
-    dispatch('close', { open });
+    if (open) {
+      open = false;
+      dispatch('close', { open });
+    }
   }
 
   function onClick(e: MouseEvent) {

--- a/packages/svelte-ux/src/lib/components/Dialog.svelte
+++ b/packages/svelte-ux/src/lib/components/Dialog.svelte
@@ -15,7 +15,8 @@
   import { getComponentClasses } from './theme.js';
 
   const dispatch = createEventDispatcher<{
-    close: { open: boolean; reason: string };
+    close: { open: boolean };
+    open: null;
   }>();
 
   export let open = false;
@@ -34,17 +35,6 @@
 
   let dialogEl: HTMLDivElement;
   let actionsEl: HTMLDivElement;
-
-  function close(options?: { force?: boolean; reason?: string }) {
-    const force = options?.force ?? false;
-    const reason = options?.reason ?? 'unknown';
-    if (open) {
-      if (!persistent || force) {
-        open = false;
-      }
-      dispatch('close', { open, reason });
-    }
-  }
 
   function onClick(e: MouseEvent) {
     try {
@@ -66,8 +56,22 @@
     }
   }
 
-  $: if (open === false) {
-    close();
+  function close(options?: { force?: boolean }) {
+    const force = options?.force ?? false;
+    if (open) {
+      if (!persistent || force) {
+        open = false;
+      } else {
+        // attempted close of persistent dialog
+        dispatch('close', { open });
+      }
+    }
+  }
+
+  $: if (open) {
+    dispatch('open');
+  } else {
+    dispatch('close', { open });
   }
 </script>
 

--- a/packages/svelte-ux/src/lib/components/Drawer.svelte
+++ b/packages/svelte-ux/src/lib/components/Drawer.svelte
@@ -13,7 +13,8 @@
 
   const dispatch = createEventDispatcher<{
     change: { open: boolean };
-    close: { open: boolean; reason: string };
+    close: { open: boolean };
+    open: null;
   }>();
 
   export let open = true;
@@ -31,15 +32,22 @@
 
   $: dispatch('change', { open });
 
-  function close(options?: { force?: boolean; reason?: string }) {
+  function close(options?: { force?: boolean }) {
     const force = options?.force ?? false;
-    const reason = options?.reason ?? 'unknown';
     if (open) {
       if (!persistent || force) {
         open = false;
+      } else {
+        // attempted close of persistent dialog
+        dispatch('close', { open });
       }
-      dispatch('close', { open, reason });
     }
+  }
+
+  $: if (open) {
+    dispatch('open');
+  } else {
+    dispatch('close', { open });
   }
 </script>
 

--- a/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
@@ -7,6 +7,9 @@
   let open = false;
   let openAsync = false;
   let loading = false;
+
+  let close: (() => void);
+  let attemptClose: (() => void);
 </script>
 
 <h1>Examples</h1>
@@ -188,8 +191,43 @@
     <Dialog {open} on:close={toggleOff} persistent>
       <div slot="title">Are you sure you want to do that?</div>
       <div slot="actions">
-        <Button variant="fill" color="primary">Yes</Button>
-        <Button>No</Button>
+        <Button variant="fill" color="primary" on:click={toggleOff}>Yes, close this dialog</Button>
+        <Button>No, keep this dialog open</Button>
+      </div>
+    </Dialog>
+  </Toggle>
+</Preview>
+
+<h2>Dispatch closing actions via slot props</h2>
+
+<Preview>
+  <Toggle let:on={open} let:toggle let:toggleOff>
+    <Button on:click={toggle}>Show Dialog</Button>
+    <Dialog
+      {open}
+      on:close={toggleOff}
+      persistent
+      let:attemptClose
+      let:close
+      on:close-attempt={() => alert('attemptClose triggered!')}
+      on:close={() => alert('close triggered!')}
+    >
+      <div class="p-5">
+        <div class="mb-4">
+          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded">close</span> and <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded">attemptClose</span> are available on every slot.
+        </div>
+        <div>
+          <Button
+            variant="fill"
+            color="primary"
+            on:click={attemptClose}
+          >Trigger attemptClose</Button>
+          <Button
+            variant="fill"
+            color="primary"
+            on:click={close}
+          >Trigger close</Button>
+      </div>
       </div>
     </Dialog>
   </Toggle>

--- a/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
@@ -8,8 +8,8 @@
   let openAsync = false;
   let loading = false;
 
-  let close: (() => void);
-  let attemptClose: (() => void);
+  let close: () => void;
+  let attemptClose: () => void;
 </script>
 
 <h1>Examples</h1>
@@ -111,6 +111,7 @@
           }}
           variant="fill"
           color="danger"
+          type="button"
         >
           Yes, delete item
         </Button>
@@ -214,20 +215,20 @@
     >
       <div class="p-5">
         <div class="mb-4">
-          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded">close</span> and <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded">attemptClose</span> are available on every slot.
+          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded"
+            >close</span
+          >
+          and
+          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded"
+            >attemptClose</span
+          > are available on every slot.
         </div>
         <div>
-          <Button
-            variant="fill"
-            color="primary"
-            on:click={attemptClose}
-          >Trigger attemptClose</Button>
-          <Button
-            variant="fill"
-            color="primary"
-            on:click={close}
-          >Trigger close</Button>
-      </div>
+          <Button variant="fill" color="primary" on:click={attemptClose}
+            >Trigger attemptClose</Button
+          >
+          <Button variant="fill" color="primary" on:click={close}>Trigger close</Button>
+        </div>
       </div>
     </Dialog>
   </Toggle>

--- a/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
@@ -108,7 +108,6 @@
           }}
           variant="fill"
           color="danger"
-          type="button"
         >
           Yes, delete item
         </Button>

--- a/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Dialog/+page.svelte
@@ -7,9 +7,6 @@
   let open = false;
   let openAsync = false;
   let loading = false;
-
-  let close: () => void;
-  let attemptClose: () => void;
 </script>
 
 <h1>Examples</h1>
@@ -189,7 +186,7 @@
 <Preview>
   <Toggle let:on={open} let:toggle let:toggleOff>
     <Button on:click={toggle}>Show Dialog</Button>
-    <Dialog {open} on:close={toggleOff} persistent>
+    <Dialog {open} persistent>
       <div slot="title">Are you sure you want to do that?</div>
       <div slot="actions">
         <Button variant="fill" color="primary" on:click={toggleOff}>Yes, close this dialog</Button>
@@ -199,35 +196,42 @@
   </Toggle>
 </Preview>
 
-<h2>Dispatch closing actions via slot props</h2>
+<h2>With close slot prop</h2>
 
 <Preview>
   <Toggle let:on={open} let:toggle let:toggleOff>
     <Button on:click={toggle}>Show Dialog</Button>
     <Dialog
       {open}
-      on:close={toggleOff}
       persistent
-      let:attemptClose
       let:close
-      on:close-attempt={() => alert('attemptClose triggered!')}
-      on:close={() => alert('close triggered!')}
+      on:close={({ detail }) => {
+        if (detail.open) {
+          alert(
+            "Attempted to close persistent Dialog without using 'force'\n\nUse 'close({ force: true })' instead of Use 'close()' to close.\n\nDialog will remain open."
+          );
+        } else {
+          alert(
+            "Persistent Dialog forced close via 'close({ force: true })'.\n\nDialog will close."
+          );
+          toggleOff();
+        }
+      }}
     >
       <div class="p-5">
         <div class="mb-4">
-          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded"
+          The <span
+            class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded"
             >close</span
-          >
-          and
-          <span class="font-mono bg-primary-700/20 text-primary-500 font-medium px-1 py-0.5 rounded"
-            >attemptClose</span
-          > are available on every slot.
+          > method is available on every slot.
         </div>
-        <div>
-          <Button variant="fill" color="primary" on:click={attemptClose}
-            >Trigger attemptClose</Button
+        <div class="grid gap-2">
+          <Button variant="fill" color="primary" on:click={() => close()}
+            >Attempt close: <code>close()</code></Button
           >
-          <Button variant="fill" color="primary" on:click={close}>Trigger close</Button>
+          <Button variant="fill" color="primary" on:click={() => close({ force: true })}
+            >Force close: <code>close({'{ force: true }'})</code></Button
+          >
         </div>
       </div>
     </Dialog>

--- a/packages/svelte-ux/src/routes/docs/components/Drawer/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Drawer/+page.svelte
@@ -149,8 +149,14 @@
     <Toggle let:on={showDrawer} let:toggleOn={openDrawer} let:toggleOff={closeDrawer}>
       <Drawer
         open={showDrawer}
-        on:close-attempt={isChanged ? openConfirmation : closeDrawer}
         persistent={isChanged}
+        on:close={({ detail }) => {
+          if (detail.open) {
+            openConfirmation();
+          } else {
+            closeDrawer();
+          }
+        }}
         class="w-[400px]"
       >
         <div class="p-4">


### PR DESCRIPTION
This PR exposes `close` and `attemptClose` methods as slot props on `Dialog` so that they can be called within slotted content programmatically, particularly `close-attempt` via `attemptClose`.