### PR TITLE
Update deprecated meta

### DIFF
--- a/packages/svelte-ux/src/app.html
+++ b/packages/svelte-ux/src/app.html
@@ -8,7 +8,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover"
     />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     %sveltekit.head%
   </head>
   <body>


### PR DESCRIPTION
Hello, this is a small fix for a deprecated meta tag
<img width="917" alt="image" src="https://github.com/user-attachments/assets/62b9ba1e-8b01-48d0-b488-dbd36b194ecc">
