### PR TITLE
Allow `onApply` to accept either a synchronous or asynchronous function

### DIFF
--- a/.changeset/blue-vans-whisper.md
+++ b/.changeset/blue-vans-whisper.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Introduce `MaybePromise` and `MaybeAsync` type helpers

--- a/.changeset/eight-ads-confess.md
+++ b/.changeset/eight-ads-confess.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Allow `onApply` to accept either a synchronous or asynchronous function

--- a/packages/svelte-ux/src/lib/components/MultiSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelect.svelte
@@ -12,7 +12,7 @@
   import MultiSelectOption from './MultiSelectOption.svelte';
   import TextField from './TextField.svelte';
 
-  import type { MenuOption } from '../types/index.js';
+  import type { MaybeAsync, MenuOption } from '../types/index.js';
   import dirtyStore from '../stores/dirtyStore.js';
   import selectionStore from '../stores/selectionStore.js';
   import uniqueStore from '../stores/uniqueStore.js';
@@ -60,7 +60,7 @@
     cancel: null;
   }>();
 
-  export let onApply = async (ctx: {
+  let defaultOnApply = (ctx: {
     value: typeof value;
     selection: typeof $selection;
     indeterminate: typeof $indeterminateStore;
@@ -68,6 +68,7 @@
   }) => {
     // no-op by default
   };
+  export let onApply: MaybeAsync<typeof defaultOnApply> = defaultOnApply;
 
   async function applyChange() {
     applying = true;

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -95,7 +95,9 @@ export type FilterPropKeys<T, Match> = {
 // Value directly or promised, useful for async functions
 export type MaybePromise<T> = T | Promise<T>;
 // Function that may be synchronous or asynchronous
-export type MaybeAsync<T extends (...args: any[]) => any> = (...args: Parameters<T>) => MaybePromise<ReturnType<T>>;
+export type MaybeAsync<T extends (...args: any[]) => any> = (
+  ...args: Parameters<T>
+) => MaybePromise<ReturnType<T>>;
 
 /**
  * @deprecated ComponentProps should be imported from 'svelte' instead of 'svelte-ux', as it is now included in the main 'svelte' package. This export may be removed in a future release.

--- a/packages/svelte-ux/src/lib/types/typeHelpers.ts
+++ b/packages/svelte-ux/src/lib/types/typeHelpers.ts
@@ -92,6 +92,11 @@ export type FilterPropKeys<T, Match> = {
   [P in keyof T]: T[P] extends Match ? P : never;
 }[keyof T];
 
+// Value directly or promised, useful for async functions
+export type MaybePromise<T> = T | Promise<T>;
+// Function that may be synchronous or asynchronous
+export type MaybeAsync<T extends (...args: any[]) => any> = (...args: Parameters<T>) => MaybePromise<ReturnType<T>>;
+
 /**
  * @deprecated ComponentProps should be imported from 'svelte' instead of 'svelte-ux', as it is now included in the main 'svelte' package. This export may be removed in a future release.
  * @see https://svelte.dev/docs/svelte#types-componentprops


### PR DESCRIPTION
- Introduce `MaybePromise` and `MaybeAsync` type helpers
- Allow `onApply` to accept either a synchronous or asynchronous function