### PR TITLE
Add basic Toast component

### DIFF
--- a/.changeset/shaggy-roses-attack.md
+++ b/.changeset/shaggy-roses-attack.md
@@ -1,5 +1,5 @@
 ---
-'svelte-ux': minor
+'svelte-ux': patch
 ---
 
 Add toast components

--- a/.changeset/shaggy-roses-attack.md
+++ b/.changeset/shaggy-roses-attack.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': minor
+---
+
+Add toast components

--- a/packages/svelte-ux/src/lib/components/Notification.svelte
+++ b/packages/svelte-ux/src/lib/components/Notification.svelte
@@ -12,6 +12,7 @@
   export let open: boolean = true;
   export let actions: 'below' | 'right' | 'split' = 'below';
   export let closeIcon: boolean = false;
+  export let onClose: (event: MouseEvent) => void = () => {};
 
   let notificationEl: HTMLDivElement;
   let actionsEl: HTMLDivElement;
@@ -79,7 +80,10 @@
         {#if closeIcon}
           <Button
             icon={mdiClose}
-            on:click={() => (open = false)}
+            on:click={(e) => {
+              open = false;
+              onClose(e);
+            }}
             class="text-surface-content/25 self-start"
           />
         {/if}

--- a/packages/svelte-ux/src/lib/components/Toast.svelte
+++ b/packages/svelte-ux/src/lib/components/Toast.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import toastStore from '$lib/stores/toastStore.js';
+  import Notification from './Notification.svelte';
+</script>
+
+<div class="fixed bottom-0 left-1/2 translate-x-[-50%] z-50 gap-y-4">
+  {#each $toastStore as toast}
+  <div class="mt-4">
+    <Notification open={true} closeIcon>
+      <span slot="title">{toast.text}</span>
+    </Notification>
+  </div>
+  {/each}
+</div>

--- a/packages/svelte-ux/src/lib/components/Toast.svelte
+++ b/packages/svelte-ux/src/lib/components/Toast.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
-  import toastStore from '$lib/stores/toastStore.js';
+  import toastStore, { removeToast } from '$lib/stores/toastStore.js';
   import Notification from './Notification.svelte';
+  import {portal} from '../actions/portal.js';
 
   import {cls} from '../utils/styles.js';
+  import Button from './Button.svelte';
 
   type Placement = 'top' | 'top-right' | 'right' | 'bottom-right' |
                    'bottom' | 'bottom-left' | 'left' | 'top-left';
 
   const DEFAULT_PLACEMENT: Placement = 'bottom';
   export let placement: Placement = DEFAULT_PLACEMENT;
+  export const classes: string = '';
 
   const isOnTop = placement.includes('top');
   const isOnBottom = placement.includes('bottom');
@@ -17,14 +20,36 @@
 </script>
 
 <div class={cls(
-  'Toast fixed z-50',
+  'Toast fixed z-50 portal-content',
   isOnTop ? 'top-0' : isOnBottom ? 'bottom-0' : 'translate-y-[-50%] top-1/2',
-  isOnLeft ? 'left-0' : isOnRight ? 'right-0'  : 'translate-x-[-50%] left-1/2'
-)}>
+  isOnLeft ? 'left-0' : isOnRight ? 'right-0'  : 'translate-x-[-50%] left-1/2',
+  classes
+)}
+ use:portal={true}
+>
   {#each $toastStore as toast}
     <div class="mt-4">
-      <Notification open={true} closeIcon>
+      <Notification open={true}
+                    closeIcon
+                    actions={toast.actionPlacement}
+                    onClose={() => {
+                      removeToast(toast);
+                    }}
+      >
         <span slot="title">{toast.text}</span>
+        <div slot="actions">
+          {#each toast.actions || [] as action}
+            <Button
+              icon={action.icon}
+              variant={action.variant}
+              rounded={action.rounded}
+              color={action.color}
+              on:click={action.onClick}
+            >
+              {action.children}
+            </Button>
+          {/each}
+        </div>
       </Notification>
     </div>
   {/each}

--- a/packages/svelte-ux/src/lib/components/Toast.svelte
+++ b/packages/svelte-ux/src/lib/components/Toast.svelte
@@ -1,9 +1,26 @@
 <script lang="ts">
   import toastStore from '$lib/stores/toastStore.js';
   import Notification from './Notification.svelte';
+
+  import {cls} from '../utils/styles.js';
+
+  type Placement = 'top' | 'top-right' | 'right' | 'bottom-right' |
+                   'bottom' | 'bottom-left' | 'left' | 'top-left';
+
+  const DEFAULT_PLACEMENT: Placement = 'bottom';
+  export let placement: Placement = DEFAULT_PLACEMENT;
+
+  const isOnTop = placement.includes('top');
+  const isOnBottom = placement.includes('bottom');
+  const isOnLeft = placement.includes('left');
+  const isOnRight = placement.includes('right');
 </script>
 
-<div class="fixed bottom-0 left-1/2 translate-x-[-50%] z-50 gap-y-4">
+<div class={cls(
+  'Toast fixed z-50',
+  isOnTop ? 'top-0' : isOnBottom ? 'bottom-0' : 'translate-y-[-50%] top-1/2',
+  isOnLeft ? 'left-0' : isOnRight ? 'right-0'  : 'translate-x-[-50%] left-1/2'
+)}>
   {#each $toastStore as toast}
     <div class="mt-4">
       <Notification open={true} closeIcon>

--- a/packages/svelte-ux/src/lib/components/Toast.svelte
+++ b/packages/svelte-ux/src/lib/components/Toast.svelte
@@ -5,10 +5,10 @@
 
 <div class="fixed bottom-0 left-1/2 translate-x-[-50%] z-50 gap-y-4">
   {#each $toastStore as toast}
-  <div class="mt-4">
-    <Notification open={true} closeIcon>
-      <span slot="title">{toast.text}</span>
-    </Notification>
-  </div>
+    <div class="mt-4">
+      <Notification open={true} closeIcon>
+        <span slot="title">{toast.text}</span>
+      </Notification>
+    </div>
   {/each}
 </div>

--- a/packages/svelte-ux/src/lib/components/index.ts
+++ b/packages/svelte-ux/src/lib/components/index.ts
@@ -91,6 +91,7 @@ export { default as ThemeInit } from './ThemeInit.svelte';
 export { default as Tilt } from './Tilt.svelte';
 export { default as Timeline } from './Timeline.svelte';
 export { default as TimelineEvent } from './TimelineEvent.svelte';
+export { default as Toast } from './Toast.svelte';
 export { default as Toggle } from './Toggle.svelte';
 export { default as ToggleButton } from './ToggleButton.svelte';
 export { default as ToggleGroup } from './ToggleGroup.svelte';

--- a/packages/svelte-ux/src/lib/stores/toastStore.ts
+++ b/packages/svelte-ux/src/lib/stores/toastStore.ts
@@ -3,20 +3,20 @@ import { get, writable } from 'svelte/store';
 const DEFAULT_TOAST_TIME_IN_MS = 3000;
 
 export type Toast = {
-  text: string,
-  timeAdded: Date
-}
+  text: string;
+  timeAdded: Date;
+};
 
 /**
  * Create a global store to save information on toast components
  */
 const toastStore = writable<Toast[]>([]);
 
-export function addToast(text: string, durationInMS=DEFAULT_TOAST_TIME_IN_MS) {
+export function addToast(text: string, durationInMS = DEFAULT_TOAST_TIME_IN_MS) {
   const timeAdded = new Date();
   const toast: Toast = {
     text,
-    timeAdded
+    timeAdded,
   };
   toastStore.set([...get(toastStore), toast]);
 

--- a/packages/svelte-ux/src/lib/stores/toastStore.ts
+++ b/packages/svelte-ux/src/lib/stores/toastStore.ts
@@ -1,0 +1,31 @@
+import { get, writable } from 'svelte/store';
+
+const DEFAULT_TOAST_TIME_IN_MS = 3000;
+
+export type Toast = {
+  text: string,
+  timeAdded: Date
+}
+
+/**
+ * Create a global store to save information on toast components
+ */
+const toastStore = writable<Toast[]>([]);
+
+export function addToast(text: string, durationInMS=DEFAULT_TOAST_TIME_IN_MS) {
+  const timeAdded = new Date();
+  const toast: Toast = {
+    text,
+    timeAdded
+  };
+  toastStore.set([...get(toastStore), toast]);
+
+  setTimeout(() => {
+    const remainingToasts = [...get(toastStore)].filter((toast) => {
+      return toast.timeAdded != timeAdded;
+    });
+    toastStore.set(remainingToasts);
+  }, durationInMS);
+}
+
+export default toastStore;

--- a/packages/svelte-ux/src/lib/stores/toastStore.ts
+++ b/packages/svelte-ux/src/lib/stores/toastStore.ts
@@ -1,21 +1,35 @@
+import type { IconInput } from '$lib/utils/icons.js';
+import type { SvelteComponent } from 'svelte';
 import { get, writable } from 'svelte/store';
 
 const DEFAULT_TOAST_TIME_IN_MS = 3000;
 
-export type Toast = {
+type ToastActionType = {
+  children?: string | SvelteComponent,
+  classes?: string,
+  onClick: () => {}
+}
+
+type ToastContents = {
   text: string;
+  actions?: ToastActionType[];
+  icon?: IconInput;
+  variant?: string // TODO:
+}
+
+type Toast = {
   timeAdded: Date;
-};
+} & ToastContents
 
 /**
  * Create a global store to save information on toast components
  */
 const toastStore = writable<Toast[]>([]);
 
-export function addToast(text: string, durationInMS = DEFAULT_TOAST_TIME_IN_MS) {
+export function addToast(toastConents: ToastContents, durationInMS = DEFAULT_TOAST_TIME_IN_MS) {
   const timeAdded = new Date();
   const toast: Toast = {
-    text,
+    ...toastConents,
     timeAdded,
   };
   toastStore.set([...get(toastStore), toast]);

--- a/packages/svelte-ux/src/routes/_NavMenu.svelte
+++ b/packages/svelte-ux/src/routes/_NavMenu.svelte
@@ -52,6 +52,7 @@
       'ResponsiveMenu',
       'Notification',
       'Popover',
+      'Toast',
       'Tooltip',
     ],
     Feedback: ['Badge', 'Progress', 'ProgressCircle'],

--- a/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import {Button} from 'svelte-ux';
+  import {Toast} from 'svelte-ux';
+  import { addToast } from '$lib/stores/toastStore.js';
+
+  function addSimpleToast(){
+    addToast('This is a simple toast!')
+  }
+
+  function addLongerToast(){
+    addToast('This is a longer toast!', 10000);
+  }
+</script>
+
+<h1>Examples</h1>
+
+<Toast />
+  <h2>Add Simple Toast</h2>
+<Button
+  variant='fill-outline'
+  color='primary'
+  on:click={addSimpleToast}
+>Click Me</Button>
+
+<h2>Add Longer Toast</h2>
+<Button
+  variant='fill-outline'
+  color='primary'
+  on:click={addLongerToast}
+>Click Me</Button>

--- a/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
-  import {Button} from 'svelte-ux';
-  import {Toast} from 'svelte-ux';
+  import { Button } from 'svelte-ux';
+  import { Toast } from 'svelte-ux';
   import { addToast } from '$lib/stores/toastStore.js';
 
-  function addSimpleToast(){
-    addToast('This is a simple toast!')
+  function addSimpleToast() {
+    addToast('This is a simple toast!');
   }
 
-  function addLongerToast(){
+  function addLongerToast() {
     addToast('This is a longer toast!', 10000);
   }
 </script>
@@ -15,16 +15,8 @@
 <h1>Examples</h1>
 
 <Toast />
-  <h2>Add Simple Toast</h2>
-<Button
-  variant='fill-outline'
-  color='primary'
-  on:click={addSimpleToast}
->Click Me</Button>
+<h2>Add Simple Toast</h2>
+<Button variant="fill-outline" color="primary" on:click={addSimpleToast}>Click Me</Button>
 
 <h2>Add Longer Toast</h2>
-<Button
-  variant='fill-outline'
-  color='primary'
-  on:click={addLongerToast}
->Click Me</Button>
+<Button variant="fill-outline" color="primary" on:click={addLongerToast}>Click Me</Button>

--- a/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
@@ -4,21 +4,35 @@
   import { addToast } from '$lib/stores/toastStore.js';
 
   function addSimpleToast() {
-    addToast({text: 'This is a simple toast'});
+    addToast('This is a simple toast');
   }
 
   function addLongerToast() {
-    addToast({text: 'This is a longer Toast'}, 300000);
+    addToast({text: 'This is a longer Toast'}, 3000);
+  }
+
+  function addToastWithBtns() {
+    addToast({
+      text: 'This has actions inside',
+      actions: [{
+        children: 'Add Another Toast',
+        onClick: addToastWithBtns,
+        color: 'primary',
+      }]
+    }, 7000);
   }
 </script>
 
 <h1>Examples</h1>
 
-<Toast
-  placement='top'
-/>
+<Toast />
 <h2>Add Simple Toast</h2>
 <Button variant="fill-outline" color="primary" on:click={addSimpleToast}>Click Me</Button>
 
 <h2>Add Longer Toast</h2>
 <Button variant="fill-outline" color="primary" on:click={addLongerToast}>Click Me</Button>
+
+<h2>With Actions</h2>
+<Button variant="fill-outline" color="primary" on:click={addToastWithBtns}>
+  With Actions
+</Button>

--- a/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/Toast/+page.svelte
@@ -4,17 +4,19 @@
   import { addToast } from '$lib/stores/toastStore.js';
 
   function addSimpleToast() {
-    addToast('This is a simple toast!');
+    addToast({text: 'This is a simple toast'});
   }
 
   function addLongerToast() {
-    addToast('This is a longer toast!', 10000);
+    addToast({text: 'This is a longer Toast'}, 300000);
   }
 </script>
 
 <h1>Examples</h1>
 
-<Toast />
+<Toast
+  placement='top'
+/>
 <h2>Add Simple Toast</h2>
 <Button variant="fill-outline" color="primary" on:click={addSimpleToast}>Click Me</Button>
 

--- a/packages/svelte-ux/src/routes/docs/components/Toast/+page.ts
+++ b/packages/svelte-ux/src/routes/docs/components/Toast/+page.ts
@@ -1,0 +1,16 @@
+import api from '$lib/components/Toast.svelte?raw&sveld';
+import source from '$lib/components/Toast.svelte?raw';
+import pageSource from './+page.svelte?raw';
+
+export async function load() {
+  return {
+    meta: {
+      api,
+      source,
+      pageSource,
+      description:
+        'Adds the ability to include Toast popup notifications that go away after a couple of seconds.',
+      related: ['components/Notification', '/customization'],
+    },
+  };
+}


### PR DESCRIPTION
Adds a basic version of a toast component that wraps Notifications and includes them on the bottom

Wanted to also leave a couple of notes before this gets merged
- I wasn't able to find any tests for components specifically in the codebase. Is there anywhere I can add these before we merge these?
- When I was testing this out, I wasn't able to initially since I got an issue, `'TZ' is not recognized as an internal or external command, operable program or batch file`. I modified the test script in package.json to be `SET TZ=UTC+4 vitest` and that let the test suite run, but failed on six-issues, not sure if it's an issue with developing on windows OS

![chrome_7oGfLfmPJR](https://github.com/user-attachments/assets/d072ed0d-a139-4e1c-9e53-8d289af4c270)

