### PR TITLE
fix(Drawer|Dialog): No longer stop mouseup event propgation, which fixes closing Menu by clicking outside (within Dialog/Drawer)

### DIFF
--- a/.changeset/many-tigers-add.md
+++ b/.changeset/many-tigers-add.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix(Drawer|Dialog): No longer stop mouseup event propgation, which fixes closing Menu by clicking outside (within Dialog/Drawer)

--- a/packages/svelte-ux/src/lib/components/Dialog.svelte
+++ b/packages/svelte-ux/src/lib/components/Dialog.svelte
@@ -99,10 +99,6 @@
       classes.root
     )}
     on:click={onClick}
-    on:mouseup={(e) => {
-      // Do not allow event to reach Popover's on:mouseup (clickOutside)
-      e.stopPropagation();
-    }}
     on:keydown={(e) => {
       if (e.key === 'Escape') {
         // Do not allow event to reach Popover's on:keydown

--- a/packages/svelte-ux/src/lib/components/Drawer.svelte
+++ b/packages/svelte-ux/src/lib/components/Drawer.svelte
@@ -106,10 +106,6 @@
         close();
       }
     }}
-    on:mouseup={(e) => {
-      // Do not allow event to reach Popover's on:mouseup (clickOutside)
-      e.stopPropagation();
-    }}
     use:portalAction={portal}
     use:focusMove={{ restoreFocus: true }}
     role="dialog"


### PR DESCRIPTION
Fixes #444

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
