### PR TITLE
Update Layerchart templates to match svelte-ux changes

### DIFF
--- a/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
+++ b/packages/create-svelte-ux/templates/layerchart/src/routes/+layout.svelte
@@ -5,13 +5,17 @@
 	import '../app.postcss';
 
 	settings({
-		classes: {
-			AppBar: 'bg-primary text-white shadow-md',
+		components: {
+			AppBar: { classes: 'bg-primary text-white shadow-md' },
 			AppLayout: {
-				nav: 'bg-neutral-800 py-2'
+				classes: {
+					nav: 'bg-neutral-800 py-2'
+				}
 			},
 			NavItem: {
-				root: 'text-sm text-gray-400 pl-6 py-2 hover:text-white hover:bg-gray-300/10 [&:where(.is-active)]:text-sky-400 [&:where(.is-active)]:bg-gray-500/10'
+				classes: {
+					root: 'text-sm text-gray-400 pl-6 py-2 hover:text-white hover:bg-gray-300/10 [&:where(.is-active)]:text-sky-400 [&:where(.is-active)]:bg-gray-500/10'
+				}
 			}
 		}
 	});


### PR DESCRIPTION
Layerchart layout provided in the template was broken
The reason was that it was not compatible with svelte-ux changes, so it has been fixed.

### before
![スクリーンショット 2024-10-23 13 55 45](https://github.com/user-attachments/assets/fbb5cb97-98a8-4123-8391-651002791903)

### after
<img width="1017" alt="スクリーンショット 2024-10-29 4 17 08" src="https://github.com/user-attachments/assets/f2fe8ec9-d282-4e4c-a718-aa3971e028a2">
