### PR TITLE
fix(MultiSelect): Resolve infinite loop when using `mode="immediate"` and Svelte 5

### DIFF
--- a/.changeset/hot-stingrays-move.md
+++ b/.changeset/hot-stingrays-move.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix(MultiSelect): Resolve infinite loop when using `mode="immediate"` and Svelte 5


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
