### PR TITLE
fix(SelectField): Properly handle option selection with option slot defined using `<svelte:fragment slot="option">` or `<div slot="option">`

### DIFF
--- a/.changeset/breezy-dingos-mate.md
+++ b/.changeset/breezy-dingos-mate.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix(SelectField): Properly handle option selection with option slot defined using `<svelte:fragment slot="option">` or `<div slot="option">`

--- a/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
+++ b/packages/svelte-ux/src/lib/components/_SelectListOptions.svelte
@@ -44,8 +44,8 @@
 
     if (e.target instanceof HTMLElement) {
       // Find slot parent of click target option, fallback to `e.target` if slot is not overridden
-      // Use `.options > ` in case slot is nested (ex. GraphQLSelect with slot)
-      const slotEl = e.target.closest('.options > [slot=option]') ?? e.target;
+      // Use `.options > *` in case slot is nested (ex. `<svelte:fragment slot="option">` vs `<div slot="option">`)
+      const slotEl = e.target.closest('.options > *') ?? e.target;
       // Find the index of the clicked on element (ignoring group headers)
       const optionIndex = slotEl
         ? [...menuOptionsEl.children]


### PR DESCRIPTION
Fixes #510

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
