### PR TITLE
feat(ThemeSwitch) Allow custom classes for icon

### DIFF
--- a/.changeset/beige-pugs-boil.md
+++ b/.changeset/beige-pugs-boil.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': minor
+---
+
+Allow custom styling of ThemeSwitch component

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -5,8 +5,16 @@
   import Icon from './Icon.svelte';
 
   import { getSettings } from './settings.js';
+  import { cls } from '../utils/index.js';
+  import type { ComponentProps } from 'svelte';
 
   const { currentTheme } = getSettings();
+
+  export let classes: {
+    icon?: string;
+  } & ComponentProps<Switch>["classes"] = {};
+
+
 </script>
 
 <Switch
@@ -26,12 +34,18 @@
     <Icon
       data={mdiWeatherNight}
       size=".8rem"
-      class="row-[1] col-[1] text-primary opacity-0 dark:opacity-100"
+      class={cls(
+        "row-[1] col-[1] text-primary opacity-0 dark:opacity-100",
+        classes.icon,
+      )}
     />
     <Icon
       data={mdiWhiteBalanceSunny}
       size=".8rem"
-      class="row-[1] col-[1] text-primary opacity-100 dark:opacity-0"
+      class={cls(
+        "row-[1] col-[1] text-primary opacity-100 dark:opacity-0",
+        classes.icon,
+      )}
     />
   </div>
 </Switch>

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -4,11 +4,15 @@
   import Switch from './Switch.svelte';
   import Icon from './Icon.svelte';
 
-  import { getSettings } from './settings.js';
+  import { getComponentSettings, getSettings } from './settings.js';
   import { cls } from '../utils/index.js';
   import type { ComponentProps } from 'svelte';
+  import { clsMerge } from '$lib/utils/styles.js';
 
   const { currentTheme } = getSettings();
+
+  const { classes: settingsClasses } = getComponentSettings('ThemeSwitch');
+
 
   export let classes: {
     icon?: string;
@@ -22,22 +26,22 @@
     let newTheme = e.target?.checked ? 'dark' : 'light';
     currentTheme.setTheme(newTheme);
   }}
-  classes={{
+  classes={clsMerge({
     switch: 'dark:bg-primary dark:border-primary',
     toggle: 'translate-x-0 dark:translate-x-full',
-  }}
+  }, settingsClasses.root, classes)}
   {...$$restProps}
 >
   <div class="grid grid-cols-1 grid-rows-1">
     <Icon
       data={mdiWeatherNight}
       size=".8rem"
-      class={cls('row-[1] col-[1] text-primary opacity-0 dark:opacity-100', classes.icon)}
+      class={cls('row-[1] col-[1] text-primary opacity-0 dark:opacity-100', settingsClasses.icon, classes.icon)}
     />
     <Icon
       data={mdiWhiteBalanceSunny}
       size=".8rem"
-      class={cls('row-[1] col-[1] text-primary opacity-100 dark:opacity-0', classes.icon)}
+      class={cls('row-[1] col-[1] text-primary opacity-100 dark:opacity-0', settingsClasses.icon, classes.icon)}
     />
   </div>
 </Switch>

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -12,9 +12,7 @@
 
   export let classes: {
     icon?: string;
-  } & ComponentProps<Switch>["classes"] = {};
-
-
+  } & ComponentProps<Switch>['classes'] = {};
 </script>
 
 <Switch
@@ -34,18 +32,12 @@
     <Icon
       data={mdiWeatherNight}
       size=".8rem"
-      class={cls(
-        "row-[1] col-[1] text-primary opacity-0 dark:opacity-100",
-        classes.icon,
-      )}
+      class={cls('row-[1] col-[1] text-primary opacity-0 dark:opacity-100', classes.icon)}
     />
     <Icon
       data={mdiWhiteBalanceSunny}
       size=".8rem"
-      class={cls(
-        "row-[1] col-[1] text-primary opacity-100 dark:opacity-0",
-        classes.icon,
-      )}
+      class={cls('row-[1] col-[1] text-primary opacity-100 dark:opacity-0', classes.icon)}
     />
   </div>
 </Switch>

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -4,14 +4,15 @@
   import Switch from './Switch.svelte';
   import Icon from './Icon.svelte';
 
-  import { getComponentSettings, getSettings } from './settings.js';
+  import { getSettings } from './settings.js';
   import { cls } from '../utils/index.js';
   import type { ComponentProps } from 'svelte';
   import { clsMerge } from '$lib/utils/styles.js';
+  import { getComponentClasses } from '$lib/components/theme.js';
 
   const { currentTheme } = getSettings();
 
-  const { classes: settingsClasses } = getComponentSettings('ThemeSwitch');
+  const { icon: iconClasses, ...otherClasses } = getComponentClasses('ThemeSwitch');
 
   export let classes: {
     icon?: string;
@@ -30,7 +31,7 @@
       switch: 'dark:bg-primary dark:border-primary',
       toggle: 'translate-x-0 dark:translate-x-full',
     },
-    settingsClasses.root,
+    otherClasses,
     classes
   )}
   {...$$restProps}
@@ -41,7 +42,7 @@
       size=".8rem"
       class={cls(
         'row-[1] col-[1] text-primary opacity-0 dark:opacity-100',
-        settingsClasses.icon,
+        iconClasses,
         classes.icon
       )}
     />
@@ -50,7 +51,7 @@
       size=".8rem"
       class={cls(
         'row-[1] col-[1] text-primary opacity-100 dark:opacity-0',
-        settingsClasses.icon,
+        iconClasses,
         classes.icon
       )}
     />

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -13,7 +13,6 @@
 
   const { classes: settingsClasses } = getComponentSettings('ThemeSwitch');
 
-
   export let classes: {
     icon?: string;
   } & ComponentProps<Switch>['classes'] = {};
@@ -26,22 +25,34 @@
     let newTheme = e.target?.checked ? 'dark' : 'light';
     currentTheme.setTheme(newTheme);
   }}
-  classes={clsMerge({
-    switch: 'dark:bg-primary dark:border-primary',
-    toggle: 'translate-x-0 dark:translate-x-full',
-  }, settingsClasses.root, classes)}
+  classes={clsMerge(
+    {
+      switch: 'dark:bg-primary dark:border-primary',
+      toggle: 'translate-x-0 dark:translate-x-full',
+    },
+    settingsClasses.root,
+    classes
+  )}
   {...$$restProps}
 >
   <div class="grid grid-cols-1 grid-rows-1">
     <Icon
       data={mdiWeatherNight}
       size=".8rem"
-      class={cls('row-[1] col-[1] text-primary opacity-0 dark:opacity-100', settingsClasses.icon, classes.icon)}
+      class={cls(
+        'row-[1] col-[1] text-primary opacity-0 dark:opacity-100',
+        settingsClasses.icon,
+        classes.icon
+      )}
     />
     <Icon
       data={mdiWhiteBalanceSunny}
       size=".8rem"
-      class={cls('row-[1] col-[1] text-primary opacity-100 dark:opacity-0', settingsClasses.icon, classes.icon)}
+      class={cls(
+        'row-[1] col-[1] text-primary opacity-100 dark:opacity-0',
+        settingsClasses.icon,
+        classes.icon
+      )}
     />
   </div>
 </Switch>

--- a/packages/svelte-ux/src/lib/components/settings.ts
+++ b/packages/svelte-ux/src/lib/components/settings.ts
@@ -150,11 +150,6 @@ export function getSettings(): Settings {
   }
 }
 
-/**
- * Returns default component props and classes for a given component.
- * @param settings global settings
- * @param name component name
- */
 export function resolveComponentSettings<NAME extends ComponentName>(
   settings: Settings,
   name: NAME
@@ -170,6 +165,10 @@ export function resolveComponentSettings<NAME extends ComponentName>(
   return output;
 }
 
+/**
+ * Returns default component props and classes for a given component.
+ * @param name component name
+ */
 export function getComponentSettings<NAME extends ComponentName>(
   name: NAME
 ): ResolvedComponentSettings<NAME> {

--- a/packages/svelte-ux/src/lib/components/settings.ts
+++ b/packages/svelte-ux/src/lib/components/settings.ts
@@ -150,6 +150,11 @@ export function getSettings(): Settings {
   }
 }
 
+/**
+ * Returns default component props and classes for a given component.
+ * @param settings global settings
+ * @param name component name
+ */
 export function resolveComponentSettings<NAME extends ComponentName>(
   settings: Settings,
   name: NAME

--- a/packages/svelte-ux/src/lib/components/theme.ts
+++ b/packages/svelte-ux/src/lib/components/theme.ts
@@ -121,6 +121,11 @@ export function resolveComponentClasses<NAME extends ComponentName>(
   return typeof theme === 'string' ? { root: theme } : (theme ?? {});
 }
 
+/**
+ * Returns default component classes for a given component. See {@link resolveComponentSettings}
+ * to get both default props and classes.
+ * @param name component name
+ */
 export function getComponentClasses<NAME extends ComponentName>(
   name: NAME
 ): ResolvedComponentClasses[NAME] {

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -14,5 +14,5 @@
 <h2>Customize Switch</h2>
 
 <Preview>
-  <ThemeSwitch classes={{ icon: 'text-yellow-100', switch: 'bg-secondary w-20', toggle: 'bg-accent' }} />
+  <ThemeSwitch classes={{ icon: 'text-primary-content', switch: 'bg-secondary w-20', toggle: 'bg-accent' }} />
 </Preview>

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -14,5 +14,7 @@
 <h2>Customize Switch</h2>
 
 <Preview>
-  <ThemeSwitch classes={{ icon: 'text-primary-content', switch: 'bg-secondary w-20', toggle: 'bg-accent' }} />
+  <ThemeSwitch
+    classes={{ icon: 'text-primary-content', switch: 'bg-secondary w-20', toggle: 'bg-accent' }}
+  />
 </Preview>

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -10,3 +10,9 @@
 <Preview>
   <ThemeSwitch />
 </Preview>
+
+<h2>Custom Icon Color</h2>
+
+<Preview>
+  <ThemeSwitch classes={{icon: 'text-yellow-500'}} />
+</Preview>

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -11,8 +11,8 @@
   <ThemeSwitch />
 </Preview>
 
-<h2>Custom Icon Color</h2>
+<h2>Customize Switch</h2>
 
 <Preview>
-  <ThemeSwitch classes={{ icon: 'text-yellow-500' }} />
+  <ThemeSwitch classes={{ icon: 'text-yellow-100', switch: 'bg-secondary w-20', toggle: 'bg-accent' }} />
 </Preview>

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -14,5 +14,5 @@
 <h2>Custom Icon Color</h2>
 
 <Preview>
-  <ThemeSwitch classes={{icon: 'text-yellow-500'}} />
+  <ThemeSwitch classes={{ icon: 'text-yellow-500' }} />
 </Preview>


### PR DESCRIPTION
### Changes
- adds the ability to pass custom classes to the underlying `Icon` components in `ThemeSwitch`.

Currently the `ThemeSwitch` icons are hard-coded to `text-primary` which makes it difficult to see the icons when using certain backgrounds (eg if my top nav bar uses the `secondary` color palette`)

Side note: This whole library is awesome and very easy to use/understand!