### PR TITLE
Resolve negative counts in pagination

### DIFF
--- a/.changeset/eleven-spiders-agree.md
+++ b/.changeset/eleven-spiders-agree.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Resolve bug causing negative counts in pagination when there are fewer items than the per page count

--- a/packages/svelte-ux/src/lib/components/Pagination.svelte
+++ b/packages/svelte-ux/src/lib/components/Pagination.svelte
@@ -20,7 +20,7 @@
   export let perPageOptions = [10, 25, 50, 100, 1000];
   export let hideSinglePage = false;
   export let format: (pagination: StoresValues<Pagination>) => string = (pagination) => {
-    return `${pagination.from.toLocaleString()}-${pagination.to.toLocaleString()} of ${pagination.total.toLocaleString()}`;
+    return `${Math.max(pagination.from, 0).toLocaleString()}-${pagination.to.toLocaleString()} of ${pagination.total.toLocaleString()}`;
   };
 
   type ShowComponent =


### PR DESCRIPTION
Resolve a bug causing negative counts in pagination when there are fewer items than the per page count

![](https://github.com/user-attachments/assets/0481b957-4399-4128-b684-b3f7f9362584)