### PR TITLE
fix(TextField): Remove `inputHolder.input` object property setter workaround for Input/textarea `bind:this` type differences as solution to fix Vite dev server freezing.  Resolve #546

### DIFF
--- a/.changeset/many-numbers-call.md
+++ b/.changeset/many-numbers-call.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix(TextField): Remove `inputHolder.input` object property setter workaround for Input/textarea `bind:this` type differences as solution to fix Vite dev server freezing

--- a/packages/svelte-ux/src/lib/components/Input.svelte
+++ b/packages/svelte-ux/src/lib/components/Input.svelte
@@ -18,7 +18,7 @@
   export let inputmode: HTMLInputAttributes['inputmode'] | undefined = undefined;
   export let id: string | undefined = undefined;
   export let actions: Actions<HTMLInputElement | HTMLTextAreaElement> | undefined = undefined;
-  export let inputEl: HTMLInputElement | null = null;
+  export let inputEl: HTMLInputElement | HTMLTextAreaElement | null = null;
   export let autocapitalize: HTMLInputAttributes['autocapitalize'] = undefined;
   let className: string | undefined = undefined;
   export { className as class };

--- a/packages/svelte-ux/src/lib/components/TextField.svelte
+++ b/packages/svelte-ux/src/lib/components/TextField.svelte
@@ -60,12 +60,6 @@
     : undefined;
   export let operators: { label: string; value: string }[] | undefined = undefined;
   export let inputEl: HTMLInputElement | HTMLTextAreaElement | null = null;
-  // this is a workaround because Input only accepts an HTMLInputElement, not a TextAreaElement
-  const inputHolder = {
-    set input(value: HTMLInputElement | null) {
-      inputEl = value;
-    },
-  };
   export let debounceChange: boolean | number = false;
   export let classes: {
     root?: string;
@@ -371,7 +365,7 @@
                 {max}
                 {step}
                 {actions}
-                bind:inputEl={inputHolder.input}
+                bind:inputEl
                 on:input={handleInput}
                 on:focus
                 on:blur


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
