### PR TITLE
fix: Do not register default light and dark themes when `settings()` context is not available. Fix interop with other frameworks (shadcn-svelte, Skeleton, etc)

### DIFF
--- a/.changeset/hip-ends-rule.md
+++ b/.changeset/hip-ends-rule.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix: Do not register default light and dark themes when `settings()` context is not available. Fix interop with other frameworks (shadcn-svelte, Skeleton, etc)

--- a/packages/svelte-ux/src/lib/components/settings.ts
+++ b/packages/svelte-ux/src/lib/components/settings.ts
@@ -134,7 +134,7 @@ let FALLBACK_SETTINGS: Settings | null = null;
 
 function getFallbackSettings() {
   FALLBACK_SETTINGS = FALLBACK_SETTINGS ?? {
-    currentTheme: createThemeStore({ light: ['light'], dark: ['dark'] }),
+    currentTheme: createThemeStore({ light: [], dark: [] }),
     componentSettingsCache: {},
     showDrawer: createShowDrawer(),
     ...createLocaleStores({}),


### PR DESCRIPTION
Without this change, the system theme within `@layerstack/svelte-stores`'s [themeStore](https://github.com/techniq/layerstack/blob/main/packages/svelte-stores/src/lib/themeStore.ts#L51-L52) will resolve as using dark mode if the system/OS has dark mode enabled (`(prefers-color-scheme: dark)`) and trigger setting `<html class="dark">` which will affect other frameworks such as shadcn-svelte and Skeleton).

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
