### PR TITLE
fix(MultiSelect): Fix reactivity scope for `filteredSelectedOptions` and `filteredUnselectedOptions`. Issue #594

### DIFF
--- a/.changeset/wise-guests-rush.md
+++ b/.changeset/wise-guests-rush.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+fix(MultiSelect): Fix reactivity scope for `filteredSelectedOptions` and `filteredUnselectedOptions`. Issue #594

--- a/packages/svelte-ux/src/lib/components/MultiSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelect.svelte
@@ -110,8 +110,8 @@
   $: usingSearch = customSearch !== false;
 
   let filteredOptions: MenuOption<TValue>[] = [...(options ?? [])];
-  let filteredSelectedOptions: MenuOption<TValue>[] = [...(selectedOptions ?? [])];
-  let filteredUnselectedOptions: MenuOption<TValue>[] = [...(unselectedOptions ?? [])];
+  $: filteredSelectedOptions = [...(selectedOptions ?? [])];
+  $: filteredUnselectedOptions = [...(unselectedOptions ?? [])];
   async function updateFilteredOptions() {
     if (usingSearch) {
       [filteredOptions, filteredSelectedOptions, filteredUnselectedOptions] = await Promise.all([

--- a/packages/svelte-ux/src/lib/components/MultiSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/MultiSelect.svelte
@@ -109,7 +109,7 @@
   $: search = typeof customSearch === 'boolean' ? defaultSearch : customSearch;
   $: usingSearch = customSearch !== false;
 
-  let filteredOptions: MenuOption<TValue>[] = [...(options ?? [])];
+  $: filteredOptions = [...(options ?? [])];
   $: filteredSelectedOptions = [...(selectedOptions ?? [])];
   $: filteredUnselectedOptions = [...(unselectedOptions ?? [])];
   async function updateFilteredOptions() {


### PR DESCRIPTION
fix #594