### PR TITLE
Fixed (Drawer/Dialog) open/close events firing on mount and unrelated…

### DIFF
--- a/.changeset/yummy-dogs-return.md
+++ b/.changeset/yummy-dogs-return.md
@@ -1,0 +1,6 @@
+---
+'svelte-ux': patch
+---
+Fixed (Drawer/Dialog) open/close events firing on mount and unrelated updates. Now events are emitted only on actual state transitions by tracking the previous open value, preventing unintended closes and focus jumps.
+Added (beforeOptions/afterOptions) slots to the (SelectField, MultiSelect, MultiSelectField, MultiSelectMenu) components.
+Updated docs examples (beforeOptions/afterOptions).

--- a/packages/svelte-ux/src/lib/components/Dialog.svelte
+++ b/packages/svelte-ux/src/lib/components/Dialog.svelte
@@ -69,7 +69,6 @@
     }
   }
 
-
   let _wasOpen = open;
   $: if (open !== _wasOpen) {
     if (open) {

--- a/packages/svelte-ux/src/lib/components/Dialog.svelte
+++ b/packages/svelte-ux/src/lib/components/Dialog.svelte
@@ -69,10 +69,15 @@
     }
   }
 
-  $: if (open) {
-    dispatch('open');
-  } else {
-    dispatch('close');
+
+  let _wasOpen = open;
+  $: if (open !== _wasOpen) {
+    if (open) {
+      dispatch('open');
+    } else if (_wasOpen) {
+      dispatch('close');
+    }
+    _wasOpen = open;
   }
 </script>
 

--- a/packages/svelte-ux/src/lib/components/Drawer.svelte
+++ b/packages/svelte-ux/src/lib/components/Drawer.svelte
@@ -45,10 +45,14 @@
     }
   }
 
-  $: if (open) {
-    dispatch('open');
-  } else {
-    dispatch('close');
+  let _wasOpen = open;
+  $: if (open !== _wasOpen) {
+    if (open) {
+      dispatch('open');
+    } else if (_wasOpen) {
+      dispatch('close');
+    }
+    _wasOpen = open;
   }
 </script>
 

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -79,7 +79,7 @@
   export let matchWidth = true;
   export let resize = true;
   export let disableTransition = false;
-    export let menuProps: ComponentProps<Menu> | undefined = undefined;
+  export let menuProps: ComponentProps<Menu> | undefined = undefined;
 
   $: filteredOptions = options ?? [];
   let searchText = '';
@@ -238,9 +238,9 @@
 
   function onChange(e: ComponentEvents<TextField>['change']) {
     logger.debug('onChange');
-  searchText = e.detail.inputValue as string;
-  dispatch('inputChange', searchText);
-  show();
+    searchText = e.detail.inputValue as string;
+    dispatch('inputChange', searchText);
+    show();
   }
 
   function onFocus() {
@@ -257,8 +257,10 @@
       fe.relatedTarget instanceof HTMLElement &&
       !menuOptionsEl?.contains(fe.relatedTarget) && // TODO: Oddly Safari does not set `relatedTarget` to the clicked on menu option (like Chrome and Firefox) but instead appears to take `tabindex` into consideration.  Currently resolves to `.options` after setting `tabindex="-1"
       fe.relatedTarget !== menuOptionsEl?.offsetParent && // click on scroll bar
-  // Allow focus to move into auxiliary slot areas (beforeOptions, afterOptions, actions)
-  !fe.relatedTarget.closest('menu > [slot=actions], menu > [slot=beforeOptions], menu > [slot=afterOptions]') && // click on action / before / after item
+      // Allow focus to move into auxiliary slot areas (beforeOptions, afterOptions, actions)
+      !fe.relatedTarget.closest(
+        'menu > [slot=actions], menu > [slot=beforeOptions], menu > [slot=afterOptions]'
+      ) && // click on action / before / after item
       !selectFieldEl?.contains(fe.relatedTarget) && // click within <SelectField> (ex. toggleIcon)
       fe.relatedTarget !== selectFieldEl // click on SelectField itself
     ) {

--- a/packages/svelte-ux/src/lib/components/SelectField.svelte
+++ b/packages/svelte-ux/src/lib/components/SelectField.svelte
@@ -79,7 +79,7 @@
   export let matchWidth = true;
   export let resize = true;
   export let disableTransition = false;
-  export let menuProps: ComponentProps<Menu> | undefined = undefined;
+    export let menuProps: ComponentProps<Menu> | undefined = undefined;
 
   $: filteredOptions = options ?? [];
   let searchText = '';
@@ -238,10 +238,9 @@
 
   function onChange(e: ComponentEvents<TextField>['change']) {
     logger.debug('onChange');
-
-    searchText = e.detail.inputValue as string;
-    dispatch('inputChange', searchText);
-    show();
+  searchText = e.detail.inputValue as string;
+  dispatch('inputChange', searchText);
+  show();
   }
 
   function onFocus() {
@@ -258,7 +257,8 @@
       fe.relatedTarget instanceof HTMLElement &&
       !menuOptionsEl?.contains(fe.relatedTarget) && // TODO: Oddly Safari does not set `relatedTarget` to the clicked on menu option (like Chrome and Firefox) but instead appears to take `tabindex` into consideration.  Currently resolves to `.options` after setting `tabindex="-1"
       fe.relatedTarget !== menuOptionsEl?.offsetParent && // click on scroll bar
-      !fe.relatedTarget.closest('menu > [slot=actions]') && // click on action item
+  // Allow focus to move into auxiliary slot areas (beforeOptions, afterOptions, actions)
+  !fe.relatedTarget.closest('menu > [slot=actions], menu > [slot=beforeOptions], menu > [slot=afterOptions]') && // click on action / before / after item
       !selectFieldEl?.contains(fe.relatedTarget) && // click within <SelectField> (ex. toggleIcon)
       fe.relatedTarget !== selectFieldEl // click on SelectField itself
     ) {
@@ -546,6 +546,7 @@
         on:close={() => hide('menu on:close')}
         {...menuProps}
       >
+        <slot name="beforeOptions" {hide} />
         <!-- TODO: Rework into hierarchy of snippets in v2.0 -->
         <SelectListOptions
           bind:menuOptionsEl
@@ -601,6 +602,7 @@
           </svelte:fragment>
         </SelectListOptions>
 
+        <slot name="afterOptions" {hide} />
         <slot name="actions" {hide} />
       </Menu>
     {:else}

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
@@ -9,6 +9,8 @@
     MultiSelect,
     MultiSelectOption,
     ToggleButton,
+    ToggleGroup,
+    ToggleOption,
   } from 'svelte-ux';
   import Preview from '$lib/components/Preview.svelte';
 
@@ -25,6 +27,15 @@
   }));
 
   let value = [3];
+
+  // Filters (Any/Evens/Odds) for demos below
+  let msSelectedStr: 'any' | 'even' | 'odds' = 'any';
+  $: msOptionsFiltered =
+    msSelectedStr === 'even'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
+      : msSelectedStr === 'odds'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+      : options;
 </script>
 
 <h1>Examples</h1>
@@ -181,6 +192,46 @@
           <div class="text-sm text-danger">Maximum selection reached</div>
         {/if}
       </div>
+    </MultiSelect>
+  </div>
+</Preview>
+
+
+
+<h2>beforeOptions slot</h2>
+
+<Preview>
+  {value.length} selected
+  <div class="flex flex-col max-h-[360px] overflow-auto">
+    <MultiSelect options={msOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)} search>
+      <svelte:fragment slot="beforeOptions" let:selection>
+        <div class="p-2 border-b">
+          <ToggleGroup bind:value={msSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+            <ToggleOption value="any">Any</ToggleOption>
+            <ToggleOption value="even">Evens</ToggleOption>
+            <ToggleOption value="odds">Odds</ToggleOption>
+          </ToggleGroup>
+        </div>
+      </svelte:fragment>
+    </MultiSelect>
+  </div>
+</Preview>
+
+<h2>afterOptions slot</h2>
+
+<Preview>
+  {value.length} selected
+  <div class="flex flex-col max-h-[360px] overflow-auto">
+    <MultiSelect options={msOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)} search>
+      <svelte:fragment slot="afterOptions" let:selection>
+        <div class="p-2 border-t">
+          <ToggleGroup bind:value={msSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+            <ToggleOption value="any">Any</ToggleOption>
+            <ToggleOption value="even">Evens</ToggleOption>
+            <ToggleOption value="odds">Odds</ToggleOption>
+          </ToggleGroup>
+        </div>
+      </svelte:fragment>
     </MultiSelect>
   </div>
 </Preview>

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelect/+page.svelte
@@ -34,8 +34,8 @@
     msSelectedStr === 'even'
       ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
       : msSelectedStr === 'odds'
-      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
-      : options;
+        ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+        : options;
 </script>
 
 <h1>Examples</h1>
@@ -196,17 +196,25 @@
   </div>
 </Preview>
 
-
-
 <h2>beforeOptions slot</h2>
 
 <Preview>
   {value.length} selected
   <div class="flex flex-col max-h-[360px] overflow-auto">
-    <MultiSelect options={msOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)} search>
+    <MultiSelect
+      options={msOptionsFiltered}
+      {value}
+      on:change={(e) => (value = e.detail.value)}
+      search
+    >
       <svelte:fragment slot="beforeOptions" let:selection>
         <div class="p-2 border-b">
-          <ToggleGroup bind:value={msSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+          <ToggleGroup
+            bind:value={msSelectedStr}
+            classes={{ options: 'justify-start h-10' }}
+            rounded="full"
+            inset
+          >
             <ToggleOption value="any">Any</ToggleOption>
             <ToggleOption value="even">Evens</ToggleOption>
             <ToggleOption value="odds">Odds</ToggleOption>
@@ -222,10 +230,20 @@
 <Preview>
   {value.length} selected
   <div class="flex flex-col max-h-[360px] overflow-auto">
-    <MultiSelect options={msOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)} search>
+    <MultiSelect
+      options={msOptionsFiltered}
+      {value}
+      on:change={(e) => (value = e.detail.value)}
+      search
+    >
       <svelte:fragment slot="afterOptions" let:selection>
         <div class="p-2 border-t">
-          <ToggleGroup bind:value={msSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+          <ToggleGroup
+            bind:value={msSelectedStr}
+            classes={{ options: 'justify-start h-10' }}
+            rounded="full"
+            inset
+          >
             <ToggleOption value="any">Any</ToggleOption>
             <ToggleOption value="even">Evens</ToggleOption>
             <ToggleOption value="odds">Odds</ToggleOption>

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
@@ -2,7 +2,15 @@
   import { slide } from 'svelte/transition';
   import { mdiPlus } from '@mdi/js';
 
-  import { Button, Drawer, MultiSelectField, MultiSelectOption, ToggleButton, ToggleGroup, ToggleOption } from 'svelte-ux';
+  import {
+    Button,
+    Drawer,
+    MultiSelectField,
+    MultiSelectOption,
+    ToggleButton,
+    ToggleGroup,
+    ToggleOption,
+  } from 'svelte-ux';
   import Preview from '$lib/components/Preview.svelte';
 
   const options = [
@@ -25,8 +33,8 @@
     msfSelectedStr === 'even'
       ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
       : msfSelectedStr === 'odds'
-      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
-      : options;
+        ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+        : options;
 </script>
 
 <h1>Examples</h1>
@@ -122,8 +130,6 @@
   />
 </Preview>
 
-
-
 <h2>Immediately apply changes (no actions) w/ maintainOrder</h2>
 
 <Preview>
@@ -185,15 +191,22 @@
   </MultiSelectField>
 </Preview>
 
-
-
 <h2>beforeOptions slot</h2>
 
 <Preview>
-  <MultiSelectField options={msfOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)}>
+  <MultiSelectField
+    options={msfOptionsFiltered}
+    {value}
+    on:change={(e) => (value = e.detail.value)}
+  >
     <svelte:fragment slot="beforeOptions">
       <div class="p-2 border-b">
-        <ToggleGroup bind:value={msfSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+        <ToggleGroup
+          bind:value={msfSelectedStr}
+          classes={{ options: 'justify-start h-10' }}
+          rounded="full"
+          inset
+        >
           <ToggleOption value="any">Any</ToggleOption>
           <ToggleOption value="even">Evens</ToggleOption>
           <ToggleOption value="odds">Odds</ToggleOption>
@@ -201,16 +214,24 @@
       </div>
     </svelte:fragment>
   </MultiSelectField>
-  
 </Preview>
 
 <h2>afterOptions slot</h2>
 
 <Preview>
-  <MultiSelectField options={msfOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)}>
+  <MultiSelectField
+    options={msfOptionsFiltered}
+    {value}
+    on:change={(e) => (value = e.detail.value)}
+  >
     <svelte:fragment slot="afterOptions">
       <div class="p-2 border-t">
-        <ToggleGroup bind:value={msfSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+        <ToggleGroup
+          bind:value={msfSelectedStr}
+          classes={{ options: 'justify-start h-10' }}
+          rounded="full"
+          inset
+        >
           <ToggleOption value="any">Any</ToggleOption>
           <ToggleOption value="even">Evens</ToggleOption>
           <ToggleOption value="odds">Odds</ToggleOption>
@@ -219,7 +240,6 @@
     </svelte:fragment>
   </MultiSelectField>
 </Preview>
-
 
 <h2>within Drawer</h2>
 

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectField/+page.svelte
@@ -2,7 +2,7 @@
   import { slide } from 'svelte/transition';
   import { mdiPlus } from '@mdi/js';
 
-  import { Button, Drawer, MultiSelectField, MultiSelectOption, ToggleButton } from 'svelte-ux';
+  import { Button, Drawer, MultiSelectField, MultiSelectOption, ToggleButton, ToggleGroup, ToggleOption } from 'svelte-ux';
   import Preview from '$lib/components/Preview.svelte';
 
   const options = [
@@ -18,6 +18,15 @@
   }));
 
   let value: number[] | undefined = [3];
+
+  // Filters (Any/Evens/Odds) for demos below
+  let msfSelectedStr: 'any' | 'even' | 'odds' = 'any';
+  $: msfOptionsFiltered =
+    msfSelectedStr === 'even'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
+      : msfSelectedStr === 'odds'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+      : options;
 </script>
 
 <h1>Examples</h1>
@@ -113,6 +122,8 @@
   />
 </Preview>
 
+
+
 <h2>Immediately apply changes (no actions) w/ maintainOrder</h2>
 
 <Preview>
@@ -173,6 +184,42 @@
     </div>
   </MultiSelectField>
 </Preview>
+
+
+
+<h2>beforeOptions slot</h2>
+
+<Preview>
+  <MultiSelectField options={msfOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)}>
+    <svelte:fragment slot="beforeOptions">
+      <div class="p-2 border-b">
+        <ToggleGroup bind:value={msfSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+          <ToggleOption value="any">Any</ToggleOption>
+          <ToggleOption value="even">Evens</ToggleOption>
+          <ToggleOption value="odds">Odds</ToggleOption>
+        </ToggleGroup>
+      </div>
+    </svelte:fragment>
+  </MultiSelectField>
+  
+</Preview>
+
+<h2>afterOptions slot</h2>
+
+<Preview>
+  <MultiSelectField options={msfOptionsFiltered} {value} on:change={(e) => (value = e.detail.value)}>
+    <svelte:fragment slot="afterOptions">
+      <div class="p-2 border-t">
+        <ToggleGroup bind:value={msfSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+          <ToggleOption value="any">Any</ToggleOption>
+          <ToggleOption value="even">Evens</ToggleOption>
+          <ToggleOption value="odds">Odds</ToggleOption>
+        </ToggleGroup>
+      </div>
+    </svelte:fragment>
+  </MultiSelectField>
+</Preview>
+
 
 <h2>within Drawer</h2>
 

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
   import { mdiPlus } from '@mdi/js';
 
-  import { Button, MultiSelectMenu, MultiSelectOption, ToggleButton, ToggleGroup, ToggleOption } from 'svelte-ux';
+  import {
+    Button,
+    MultiSelectMenu,
+    MultiSelectOption,
+    ToggleButton,
+    ToggleGroup,
+    ToggleOption,
+  } from 'svelte-ux';
   import Preview from '$lib/components/Preview.svelte';
 
   const options = [
@@ -24,8 +31,8 @@
     msmSelectedStr === 'even'
       ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
       : msmSelectedStr === 'odds'
-      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
-      : options;
+        ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+        : options;
 </script>
 
 <h1>Examples</h1>
@@ -305,8 +312,6 @@
   </span>
 </Preview>
 
-
-
 <h2>beforeOptions slot</h2>
 
 <Preview>
@@ -327,7 +332,12 @@
       >
         <svelte:fragment slot="beforeOptions">
           <div class="p-2 border-b">
-            <ToggleGroup bind:value={msmSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+            <ToggleGroup
+              bind:value={msmSelectedStr}
+              classes={{ options: 'justify-start h-10' }}
+              rounded="full"
+              inset
+            >
               <ToggleOption value="any">Any</ToggleOption>
               <ToggleOption value="even">Evens</ToggleOption>
               <ToggleOption value="odds">Odds</ToggleOption>
@@ -359,7 +369,12 @@
       >
         <svelte:fragment slot="afterOptions">
           <div class="p-2 border-t">
-            <ToggleGroup bind:value={msmSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+            <ToggleGroup
+              bind:value={msmSelectedStr}
+              classes={{ options: 'justify-start h-10' }}
+              rounded="full"
+              inset
+            >
               <ToggleOption value="any">Any</ToggleOption>
               <ToggleOption value="even">Evens</ToggleOption>
               <ToggleOption value="odds">Odds</ToggleOption>
@@ -370,7 +385,6 @@
     </ToggleButton>
   </span>
 </Preview>
-
 
 <h2>option slot</h2>
 

--- a/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/MultiSelectMenu/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { mdiPlus } from '@mdi/js';
 
-  import { Button, MultiSelectMenu, MultiSelectOption, ToggleButton } from 'svelte-ux';
+  import { Button, MultiSelectMenu, MultiSelectOption, ToggleButton, ToggleGroup, ToggleOption } from 'svelte-ux';
   import Preview from '$lib/components/Preview.svelte';
 
   const options = [
@@ -17,6 +17,15 @@
   }));
 
   let value = [3];
+
+  // Filters (Any/Evens/Odds) for demos below
+  let msmSelectedStr: 'any' | 'even' | 'odds' = 'any';
+  $: msmOptionsFiltered =
+    msmSelectedStr === 'even'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
+      : msmSelectedStr === 'odds'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+      : options;
 </script>
 
 <h1>Examples</h1>
@@ -91,7 +100,6 @@
     </ToggleButton>
   </div>
 </Preview>
-
 <h2>search</h2>
 
 <Preview>
@@ -296,6 +304,73 @@
     </ToggleButton>
   </span>
 </Preview>
+
+
+
+<h2>beforeOptions slot</h2>
+
+<Preview>
+  <span>
+    <ToggleButton let:on={open} let:toggleOff transition={false}>
+      {value.length} selected
+      <MultiSelectMenu
+        options={msmOptionsFiltered}
+        {value}
+        on:change={(e) => {
+          // @ts-expect-error
+          value = e.detail.value;
+        }}
+        {open}
+        on:close={toggleOff}
+        classes={{ menu: 'w-[360px]' }}
+        search
+      >
+        <svelte:fragment slot="beforeOptions">
+          <div class="p-2 border-b">
+            <ToggleGroup bind:value={msmSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+              <ToggleOption value="any">Any</ToggleOption>
+              <ToggleOption value="even">Evens</ToggleOption>
+              <ToggleOption value="odds">Odds</ToggleOption>
+            </ToggleGroup>
+          </div>
+        </svelte:fragment>
+      </MultiSelectMenu>
+    </ToggleButton>
+  </span>
+</Preview>
+
+<h2>afterOptions slot</h2>
+
+<Preview>
+  <span>
+    <ToggleButton let:on={open} let:toggleOff transition={false}>
+      {value.length} selected
+      <MultiSelectMenu
+        options={msmOptionsFiltered}
+        {value}
+        on:change={(e) => {
+          // @ts-expect-error
+          value = e.detail.value;
+        }}
+        {open}
+        on:close={toggleOff}
+        classes={{ menu: 'w-[360px]' }}
+        search
+      >
+        <svelte:fragment slot="afterOptions">
+          <div class="p-2 border-t">
+            <ToggleGroup bind:value={msmSelectedStr} classes={{ options: 'justify-start h-10' }} rounded="full" inset>
+              <ToggleOption value="any">Any</ToggleOption>
+              <ToggleOption value="even">Evens</ToggleOption>
+              <ToggleOption value="odds">Odds</ToggleOption>
+            </ToggleGroup>
+          </div>
+        </svelte:fragment>
+      </MultiSelectMenu>
+    </ToggleButton>
+  </span>
+</Preview>
+
 
 <h2>option slot</h2>
 

--- a/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
@@ -79,8 +79,8 @@
     selectedStr === 'even'
       ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
       : selectedStr === 'odds'
-      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
-      : options;
+        ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+        : options;
 </script>
 
 <h1>Examples</h1>
@@ -504,22 +504,32 @@
 <h2>`beforeOptions` slot (menu)</h2>
 
 <Preview>
-  <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>  
+  <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>
     <div slot="beforeOptions" class="p-2 border-b" on:click|stopPropagation let:hide role="none">
-      <ToggleGroup bind:value={selectedStr} classes={{ options: "justify-start h-10" }} rounded="full" inset>
+      <ToggleGroup
+        bind:value={selectedStr}
+        classes={{ options: 'justify-start h-10' }}
+        rounded="full"
+        inset
+      >
         <ToggleOption value="any">Any</ToggleOption>
         <ToggleOption value="even">Evens</ToggleOption>
         <ToggleOption value="odds">Odds</ToggleOption>
       </ToggleGroup>
     </div>
   </SelectField>
-</Preview><h2>`afterOptions` slot (menu)</h2>
+</Preview>
+<h2>`afterOptions` slot (menu)</h2>
 
 <Preview>
-   <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>  
+  <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>
     <div slot="afterOptions" class="p-2 border-t" on:click|stopPropagation let:hide role="none">
-      
-      <ToggleGroup bind:value={selectedStr} classes={{ options: "justify-start h-10" }} rounded="full" inset>
+      <ToggleGroup
+        bind:value={selectedStr}
+        classes={{ options: 'justify-start h-10' }}
+        rounded="full"
+        inset
+      >
         <ToggleOption value="any">Any</ToggleOption>
         <ToggleOption value="even">Evens</ToggleOption>
         <ToggleOption value="odds">Odds</ToggleOption>

--- a/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/SelectField/+page.svelte
@@ -11,6 +11,8 @@
     State,
     TextField,
     Toggle,
+    ToggleGroup,
+    ToggleOption,
     type MenuOption,
   } from 'svelte-ux';
   import { cls } from '@layerstack/tailwind';
@@ -69,6 +71,16 @@
   let loading = false;
 
   let value = 3;
+
+  let selectedStr: 'any' | 'even' | 'odds' = 'any';
+
+  // Filter options based on toggle selection
+  $: optionsFiltered =
+    selectedStr === 'even'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 === 0)
+      : selectedStr === 'odds'
+      ? options.filter((o) => typeof o.value === 'number' && o.value % 2 !== 0)
+      : options;
 </script>
 
 <h1>Examples</h1>
@@ -436,7 +448,6 @@
     </Form>
   </Toggle>
 </Preview>
-
 <h2>`actions` slot (menu)</h2>
 
 <Preview>
@@ -486,6 +497,33 @@
           </Dialog>
         </Form>
       </Toggle>
+    </div>
+  </SelectField>
+</Preview>
+
+<h2>`beforeOptions` slot (menu)</h2>
+
+<Preview>
+  <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>  
+    <div slot="beforeOptions" class="p-2 border-b" on:click|stopPropagation let:hide role="none">
+      <ToggleGroup bind:value={selectedStr} classes={{ options: "justify-start h-10" }} rounded="full" inset>
+        <ToggleOption value="any">Any</ToggleOption>
+        <ToggleOption value="even">Evens</ToggleOption>
+        <ToggleOption value="odds">Odds</ToggleOption>
+      </ToggleGroup>
+    </div>
+  </SelectField>
+</Preview><h2>`afterOptions` slot (menu)</h2>
+
+<Preview>
+   <SelectField options={optionsFiltered} bind:value menuProps={{ explicitClose: true }}>  
+    <div slot="afterOptions" class="p-2 border-t" on:click|stopPropagation let:hide role="none">
+      
+      <ToggleGroup bind:value={selectedStr} classes={{ options: "justify-start h-10" }} rounded="full" inset>
+        <ToggleOption value="any">Any</ToggleOption>
+        <ToggleOption value="even">Evens</ToggleOption>
+        <ToggleOption value="odds">Odds</ToggleOption>
+      </ToggleGroup>
     </div>
   </SelectField>
 </Preview>


### PR DESCRIPTION
… updates. Now events are emitted only on actual state transitions by tracking the previous open value, preventing unintended closes and focus jumps.

Added (beforeOptions/afterOptions) slots to the (SelectField, MultiSelect, MultiSelectField, MultiSelectMenu) components. Updated docs examples (beforeOptions/afterOptions).