### PR TITLE
Theme events patch (property rename)

### DIFF
--- a/.changeset/lucky-gifts-glow.md
+++ b/.changeset/lucky-gifts-glow.md
@@ -1,0 +1,5 @@
+---
+'svelte-ux': patch
+---
+
+Replace event.detail.detail with event.detail.theme

--- a/.changeset/lucky-gifts-glow.md
+++ b/.changeset/lucky-gifts-glow.md
@@ -2,4 +2,4 @@
 'svelte-ux': patch
 ---
 
-Replace event.detail.detail with event.detail.theme
+Use `theme` instead of `detail` for `themeSet` event property

--- a/packages/svelte-ux/src/lib/components/ThemeSelect.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSelect.svelte
@@ -35,12 +35,12 @@
         // Pick next theme
         const currentIndex = themes.indexOf($currentTheme.resolvedTheme);
         let newTheme = themes[(currentIndex + 1) % themes.length];
-        dispatch('themeSet', { detail: newTheme });
+        dispatch('themeSet', { theme: newTheme });
         currentTheme.setTheme(newTheme);
       } else {
         // Toggle light/dark
         let newTheme = $currentTheme.dark ? 'light' : 'dark';
-        dispatch('themeSet', { detail: newTheme });
+        dispatch('themeSet', { theme: newTheme });
         currentTheme.setTheme(newTheme);
       }
     }
@@ -81,7 +81,7 @@
                 size="sm"
                 class="mr-1"
                 on:click={() => {
-                  dispatch('themeSet', { detail: 'system' });
+                  dispatch('themeSet', { theme: 'system' });
                   currentTheme.setTheme('system');
                 }}
               />
@@ -95,7 +95,7 @@
           on:change={(e) => {
             // @ts-expect-error: <input type="checkbox"> has `checked`, but difficult to type without dispatching custom event
             let newTheme = e.target?.checked ? 'dark' : 'light';
-            dispatch('themeSet', { detail: newTheme });
+            dispatch('themeSet', { theme: newTheme });
             currentTheme.setTheme(newTheme);
           }}
           class="my-1"
@@ -113,7 +113,7 @@
         {#each themes as themeName}
           <MenuItem
             on:click={() => {
-              dispatch('themeSet', { detail: themeName });
+              dispatch('themeSet', { theme: themeName });
               currentTheme.setTheme(themeName);
             }}
             data-theme={themeName}
@@ -166,7 +166,7 @@
         icon={icons.lightMode}
         selected={$currentTheme.theme === 'light'}
         on:click={() => {
-          dispatch('themeSet', { detail: 'light' });
+          dispatch('themeSet', { theme: 'light' });
           currentTheme.setTheme('light');
         }}
       >
@@ -177,7 +177,7 @@
         icon={icons.darkMode}
         selected={$currentTheme.theme === 'dark'}
         on:click={() => {
-          dispatch('themeSet', { detail: 'dark' });
+          dispatch('themeSet', { theme: 'dark' });
           currentTheme.setTheme('dark');
         }}
       >
@@ -188,7 +188,7 @@
         icon={icons.monitor}
         selected={$currentTheme.theme == null}
         on:click={() => {
-          dispatch('themeSet', { detail: 'system' });
+          dispatch('themeSet', { theme: 'system' });
           currentTheme.setTheme('system');
         }}
       >

--- a/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
+++ b/packages/svelte-ux/src/lib/components/ThemeSwitch.svelte
@@ -24,7 +24,7 @@
   on:change={(e) => {
     // @ts-expect-error: <input type="checkbox"> has `checked`, but difficult to type without dispatching custom event
     let newTheme = e.target?.checked ? 'dark' : 'light';
-    dispatch('themeSet', { detail: newTheme });
+    dispatch('themeSet', { theme: newTheme });
     currentTheme.setTheme(newTheme);
   }}
   classes={clsMerge(

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSelect/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSelect/+page.svelte
@@ -24,3 +24,9 @@
   <!-- Use docs themes for convenience of many themes -->
   <ThemeSelect lightThemes={data.themes.light} darkThemes={data.themes.dark} />
 </Preview>
+
+<h2>Change event</h2>
+
+<Preview>
+  <ThemeSelect on:themeSet={(e) => console.log(e.detail.theme)} />
+</Preview>

--- a/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
+++ b/packages/svelte-ux/src/routes/docs/components/ThemeSwitch/+page.svelte
@@ -18,3 +18,9 @@
     classes={{ icon: 'text-primary-content', switch: 'bg-secondary w-20', toggle: 'bg-accent' }}
   />
 </Preview>
+
+<h2>Change event</h2>
+
+<Preview>
+  <ThemeSwitch on:themeSet={(e) => console.log(e.detail.theme)} />
+</Preview>


### PR DESCRIPTION
This PR renames the detail property in the events dispatched from theme components to theme. This affects usage downstream.

Before:

```ts
on:themeSet={(e) => {
  console.log(e.detail.detail);
}}
```

After:

```ts
on:themeSet={(e) => {
  console.log(e.detail.theme);
}}
```

It removes redundancy and is a little clearer to read/use.